### PR TITLE
Add -ss to encoding options

### DIFF
--- a/lib/ffmpeg/encoding_options.rb
+++ b/lib/ffmpeg/encoding_options.rb
@@ -135,6 +135,10 @@ module FFMPEG
     def convert_keyframe_interval(value)
       "-g #{value}"
     end
+
+    def convert_seek_time(value)
+      "-ss #{value}"
+    end
     
     def convert_custom(value)
       value

--- a/spec/ffmpeg/encoding_options_spec.rb
+++ b/spec/ffmpeg/encoding_options_spec.rb
@@ -110,6 +110,10 @@ module FFMPEG
       it "should convert file preset" do
         EncodingOptions.new(:file_preset => "max.ffpreset").to_s.should == "-fpre max.ffpreset"
       end
+
+      it "should specify seek time" do
+        EncodingOptions.new(:seek_time => 1).to_s.should == "-ss 1"
+      end
       
       it "should put the parameters in order of codecs, presets, others" do
         opts = Hash.new


### PR DESCRIPTION
Adds seek_time method to encoding options hash, which enables selecting a seek time.

I realize this is a pretty tiny pull request, but this is an option I'd find useful. ;)
