### PR TITLE
Fix too many open files error

### DIFF
--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -9,8 +9,8 @@ module FFMPEG
       
       @path = escape(path)
 
-      stdin, stdout, stderr = Open3.popen3("#{FFMPEG.ffmpeg_binary} -i '#{path}'") # Output will land in stderr
-      output = stderr.read
+      # Output will land in stderr
+      output = Open3.popen3("#{FFMPEG.ffmpeg_binary} -i '#{path}'"){| stdin, stdout, stderr | stderr.read }
       
       fix_encoding(output)
       

--- a/spec/ffmpeg/movie_spec.rb
+++ b/spec/ffmpeg/movie_spec.rb
@@ -30,6 +30,14 @@ module FFMPEG
         end
       end
       
+      describe "Errno::EMFILE: Too many open files" do
+        it "should not raise error" do
+          lambda {
+            128.times { Movie.new("#{fixture_path}/sounds/napoleon.mp3") }
+          }.should_not raise_error(Errno::EMFILE, /Too many open files/)
+        end
+      end
+
       describe "a broken mp4 file" do
         before(:all) do
           @movie = Movie.new("#{fixture_path}/movies/broken.mp4")
@@ -61,7 +69,7 @@ module FFMPEG
       describe "given a file with start-time" do
         before(:each) do
           fake_output = StringIO.new(File.read("#{fixture_path}/outputs/file_with_start_value.txt"))
-          Open3.stub!(:popen3).and_return([nil,nil,fake_output])
+          Open3.stub!(:popen3).and_yield(nil, nil, fake_output)
           @movie = Movie.new(__FILE__)
         end
         
@@ -73,7 +81,7 @@ module FFMPEG
       describe "given a file with ISO-8859-1 characters in output" do
         it "should not crash" do
           fake_output = StringIO.new(File.read("#{fixture_path}/outputs/file_with_iso-8859-1.txt"))
-          Open3.stub!(:popen3).and_return([nil,nil,fake_output])
+          Open3.stub!(:popen3).and_yield(nil, nil, fake_output)
           expect { Movie.new(__FILE__) }.to_not raise_error
         end
       end
@@ -81,7 +89,7 @@ module FFMPEG
       describe "given a file with 5.1 audio" do
         before(:each) do
           fake_output = StringIO.new(File.read("#{fixture_path}/outputs/file_with_surround_sound.txt"))
-          Open3.stub!(:popen3).and_return([nil,nil,fake_output])
+          Open3.stub!(:popen3).and_yield(nil, nil, fake_output)
           @movie = Movie.new(__FILE__)
         end
         
@@ -93,7 +101,7 @@ module FFMPEG
       describe "given a file with no audio" do
         before(:each) do
           fake_output = StringIO.new(File.read("#{fixture_path}/outputs/file_with_no_audio.txt"))
-          Open3.stub!(:popen3).and_return([nil,nil,fake_output])
+          Open3.stub!(:popen3).and_yield(nil, nil, fake_output)
           @movie = Movie.new(__FILE__)
         end
         
@@ -105,7 +113,7 @@ module FFMPEG
       describe "given a file with non supported audio" do
         before(:each) do
           fake_output = StringIO.new(File.read("#{fixture_path}/outputs/file_with_non_supported_audio.txt"))
-          Open3.stub!(:popen3).and_return([nil,nil,fake_output])
+          Open3.stub!(:popen3).and_yield(nil, nil, fake_output)
           @movie = Movie.new(__FILE__)
         end
         


### PR DESCRIPTION
popen3 stdin not close
### Reproduce code

```
#!/usr/local/bin/ruby -Ku
require "rubygems"
require "streamio-ffmpeg"
`convert logo: sample.jpg`
200.times{|i|@i=i;FFMPEG::Movie.new("sample.jpg")} rescue (p [@i, $!]) #=> [81, #<Errno::EMFILE: Too many open files>]
p RUBY_VERSION    #=> "1.8.7"
p FFMPEG::VERSION #=> "0.8.4"
```
### before fix

```
~/src/streamio-ffmpeg $ rake spec
/opt/local/bin/ruby -S rspec spec/ffmpeg/encoding_options_spec.rb spec/ffmpeg/movie_spec.rb spec/ffmpeg/transcoder_spec.rb spec/streamio-ffmpeg_spec.rb
................................FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF*FFFFFFFFFF.....
Finished in 2.9 seconds
85 examples, 47 failures, 1 pending
```
### after fix

```
~/src/streamio-ffmpeg $ rake spec
/opt/local/bin/ruby -S rspec spec/ffmpeg/encoding_options_spec.rb spec/ffmpeg/movie_spec.rb spec/ffmpeg/transcoder_spec.rb spec/streamio-ffmpeg_spec.rb
.....................................................................*...............
Finished in 21.74 seconds
85 examples, 0 failures, 1 pending
```
