### PR TITLE
workaround ffmpeg bug detecting start position in x264

### DIFF
--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -24,7 +24,9 @@ module FFMPEG
     # ffmpeg <  0.8: frame=  413 fps= 48 q=31.0 size=    2139kB time=16.52 bitrate=1060.6kbits/s
     # ffmpeg >= 0.8: frame= 4855 fps= 46 q=31.0 size=   45306kB time=00:02:42.28 bitrate=2287.0kbits/
     def run
-      command = "#{FFMPEG.ffmpeg_binary} -y -i #{Shellwords.escape(@movie.path)} #{@raw_options} '#{@output_file}'"
+      seek_time = @raw_options.delete(:seek_time)
+      seek_time = '-ss %d' % seek_time if seek_time
+      command = "#{FFMPEG.ffmpeg_binary} -y #{seek_time} -i #{Shellwords.escape(@movie.path)} #{@raw_options} '#{@output_file}'"
       FFMPEG.logger.info("Running transcoding...\n#{command}\n")
       output = ""
       last_output = nil


### PR DESCRIPTION
This workaround is made mostly to workaround screenshot issue when it takes 100% CPU and minutes to generate a single screenshot (refs #32) from x264 streams, also happens when you start transcoding not from the start. I catch this bug on debian-multimedia ffmpeg builds versions 0.7.x, 0.8.x, and on self-build ffmpeg version 0.9. 
