### PR TITLE
Remove stray == from transcoder spec.

### DIFF
--- a/spec/ffmpeg/transcoder_spec.rb
+++ b/spec/ffmpeg/transcoder_spec.rb
@@ -88,7 +88,7 @@ module FFMPEG
         encoded.video_codec.should =~ /h264/
         encoded.resolution.should == "320x240"
         encoded.frame_rate.should == 10.0
-        encoded.audio_bitrate.should == be_within(2).of(32)
+        encoded.audio_bitrate.should be_within(2).of(32)
         encoded.audio_codec.should =~ /aac/
         encoded.audio_sample_rate.should == 22050
         encoded.audio_channels.should == 1


### PR DESCRIPTION
An extra == in the transcoder spec was causing a test failure:

```
Failures:

  1) FFMPEG::Transcoder transcoding should transcode the movie with EncodingOptions
     Failure/Error: encoded.audio_bitrate.should == be_within(2).of(32)
       expected: #<RSpec::Matchers::BuiltIn::BeWithin:0x007fe7fa0dc890 @delta=2, @expected=32>
            got: 31 (using ==)
     # ./spec/ffmpeg/transcoder_spec.rb:91:in `block (3 levels) in <module:FFMPEG>'
```

Thank you for a great gem!

-John
