### PR TITLE
Fix frame_rate for invalid videos

### DIFF
--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -85,6 +85,7 @@ module FFMPEG
     end
     
     def frame_rate
+      return nil if video_stream.nil? 
       video_stream[/(\d*\.?\d*)\s?fps/] ? $1.to_f : nil
     end
     

--- a/spec/ffmpeg/movie_spec.rb
+++ b/spec/ffmpeg/movie_spec.rb
@@ -28,6 +28,22 @@ module FFMPEG
         it "should not be valid" do
           @movie.should_not be_valid
         end
+        
+        it "should have a duration of 0" do
+          @movie.duration.should == 0
+        end 
+        
+        it "should have nil height" do
+          @movie.height.should be_nil
+        end
+        
+        it "should have nil width" do
+          @movie.width.should be_nil
+        end
+      
+        it "should have nil frame_rate" do
+          @movie.frame_rate.should be_nil
+        end 
       end
 
       context "given an empty flv file (could not find codec parameters)" do


### PR DESCRIPTION
Fixes problem in which for invalid movie objects the frame_rate method raises a NoMethodError while width and height return nil and duration returns 0.  

This fixes the NoMethodError by returning nil (in the manner of width and height).
