### PR TITLE
Autorotate option for #transcode and #screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Installation
 
     (sudo) gem install streamio-ffmpeg
 
-This version is tested against ffmpeg 0.11.1. So no guarantees with earlier (or much later) versions. Output and input standards have inconveniently changed rather a lot between versions of ffmpeg. My goal is to keep this library in sync with new versions of ffmpeg as they come along.
+This version is tested against ffmpeg 1.0. So no guarantees with earlier (or much later) versions. Output and input standards have inconveniently changed rather a lot between versions of ffmpeg. My goal is to keep this library in sync with new versions of ffmpeg as they come along.
 
 Usage
 -----

--- a/README.md
+++ b/README.md
@@ -109,6 +109,27 @@ transcoder_options = {:preserve_aspect_ratio => :height}
 widescreen_movie.transcode("movie.mp4", options, transcoder_options) # Output resolution will be 426x240
 ```
 
+Disable the enlarge transcoding option to avoid lossy scaling.
+
+``` ruby
+# With original resolution will be 640x480
+encoding_options = {:resolution => "1080x2"}
+transcoder_options = {:preserve_aspect_ratio => :width, :enlarge => false}
+# The movie will not be scaled up
+
+encoding_options = {:resolution => "320x2"}
+transcoder_options = {:preserve_aspect_ratio => :width, :enlarge => false}
+# The movie will be scaled down to output resolution "320x240"
+```
+
+Active autorotate transcoder option to autorotate videos that have metadata rotation.
+``` ruby
+# given the movie with original resolution "640x480", rotation "90"
+widescreen_movie.transcode("movie.mp4", options, {:autorotate => true}) 
+# The movie is rotated 90 degrees counterclockwise
+# Output resolution is "480x640"
+```
+
 For constant bitrate encoding use video_min_bitrate and video_max_bitrate with buffer_size.
 
 ``` ruby

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ widescreen_movie.transcode("movie.mp4", options, transcoder_options) # Output re
 Disable the enlarge transcoding option to avoid lossy scaling.
 
 ``` ruby
-# With original resolution will be 640x480
+# With original resolution "640x480"
 encoding_options = {:resolution => "1080x2"}
 transcoder_options = {:preserve_aspect_ratio => :width, :enlarge => false}
 # The movie will not be scaled up
@@ -124,10 +124,9 @@ transcoder_options = {:preserve_aspect_ratio => :width, :enlarge => false}
 
 Active autorotate transcoder option to autorotate videos that have metadata rotation.
 ``` ruby
-# given the movie with original resolution "640x480", rotation "90"
+# With original resolution "640x480", rotation "90"
 widescreen_movie.transcode("movie.mp4", options, {:autorotate => true}) 
-# The movie is rotated 90 degrees counterclockwise
-# Output resolution is "480x640"
+# The movie is rotated 90 degrees counterclockwise to output resolution "480x640"
 ```
 
 For constant bitrate encoding use video_min_bitrate and video_max_bitrate with buffer_size.

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ transcoder_options = {:preserve_aspect_ratio => :width, :enlarge => false}
 Activate autorotate transcoder option to autorotate videos that have metadata rotation.
 ``` ruby
 # With original resolution "640x480", rotation "90"
-widescreen_movie.transcode("movie.mp4", options, {:autorotate => true}) 
+transcoder_options = {:autoroate => true}
 # The movie is rotated 90 degrees counterclockwise to output resolution "480x640"
 ```
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ transcoder_options = {:preserve_aspect_ratio => :width, :enlarge => false}
 # The movie will be scaled down to output resolution "320x240"
 ```
 
-Active autorotate transcoder option to autorotate videos that have metadata rotation.
+Activate autorotate transcoder option to autorotate videos that have metadata rotation.
 ``` ruby
 # With original resolution "640x480", rotation "90"
 widescreen_movie.transcode("movie.mp4", options, {:autorotate => true}) 

--- a/lib/ffmpeg/encoding_options.rb
+++ b/lib/ffmpeg/encoding_options.rb
@@ -132,6 +132,14 @@ module FFMPEG
       value
     end
     
+    def convert_metadata(value)
+      "-metadata:#{value}"
+    end
+
+    def convert_video_filter(value)
+      "-vf #{value}"
+    end
+    
     def k_format(value)
       value.to_s.include?("k") ? value : "#{value}k"
     end

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -97,19 +97,47 @@ module FFMPEG
     
     private
     def apply_transcoder_options
-      return if @movie.calculated_aspect_ratio.nil?
+      autorotate = (@transcoder_options[:autorotate] && @movie.rotation)
+      apply_autorotate if autorotate
+      apply_preserve_aspect_ratio(autorotate) if @movie.calculated_aspect_ratio
+    end
+    
+    def apply_autorotate
+      # remove the rotation information on the video stream so rotation-aware players don't rotate twice
+      @raw_options[:metadata] = 's:v:0 rotate=0'
+      filters = {
+        90  => 'transpose=1',
+        180 => 'hflip,vflip',
+        270 => 'transpose=2'
+      }
+      @raw_options[:video_filter] = filters[@movie.rotation]
+    end
+    
+    def apply_preserve_aspect_ratio(autorotate = false)
       case @transcoder_options[:preserve_aspect_ratio].to_s
       when "width"
-        new_height = @raw_options.width / @movie.calculated_aspect_ratio
-        new_height = new_height.ceil.even? ? new_height.ceil : new_height.floor
-        new_height += 1 if new_height.odd? # needed if new_height ended up with no decimals in the first place
+        new_height = @raw_options.width / aspect_ratio(autorotate)
+        new_height = evenize(new_height)
         @raw_options[:resolution] = "#{@raw_options.width}x#{new_height}"
       when "height"
-        new_width = @raw_options.height * @movie.calculated_aspect_ratio
-        new_width = new_width.ceil.even? ? new_width.ceil : new_width.floor
-        new_width += 1 if new_width.odd?
+        new_width = @raw_options.height * aspect_ratio(autorotate)
+        new_width = evenize(new_width)
         @raw_options[:resolution] = "#{new_width}x#{@raw_options.height}"
       end
+    end
+    
+    def aspect_ratio(autorotate)
+      if (autorotate && [90, 270].include?(@movie.rotation))
+        1 / @movie.calculated_aspect_ratio
+      else
+        @movie.calculated_aspect_ratio
+      end
+    end
+    
+    # ffmpeg requires full, even numbers for its resolution string -- this method ensures that
+    def evenize(number)
+      number = number.ceil.even? ? number.ceil : number.floor
+      number.odd? ? number += 1 : number # needed if new_height ended up with no decimals in the first place
     end
     
     def fix_encoding(output)

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -5,6 +5,10 @@ require 'ffmpeg/transcoders/scaler'
 
 module FFMPEG
 
+  # transcoder options:
+  # - preserve_aspect_ration: [:width|:height]
+  # - scale_and_enlarge: boolean, default: true 
+  # - autorotate: boolean
   class Transcoder
 
     include FFMPEG::Transcoders::Autorotator
@@ -20,7 +24,7 @@ module FFMPEG
       @@timeout
     end
 
-    def initialize(movie, output_file, options = EncodingOptions.new, transcoder_options = {})
+    def initialize(movie, output_file, options = EncodingOptions.new, transcoder_options = {:enlarge => true})
       @movie = movie
       @output_file = output_file
       

--- a/lib/ffmpeg/transcoders/autorotator.rb
+++ b/lib/ffmpeg/transcoders/autorotator.rb
@@ -1,0 +1,27 @@
+module FFMPEG
+  module Transcoders
+    module Autorotator
+      def apply_autorotate
+        return unless autorotate?
+        # remove the rotation information on the video stream so rotation-aware players don't rotate twice
+        @raw_options[:metadata] = 's:v:0 rotate=0'
+        filters = {
+          90  => 'transpose=1',
+          180 => 'hflip,vflip',
+          270 => 'transpose=2'
+        }
+        @raw_options[:video_filter] = filters[@movie.rotation]
+      end
+
+      # we need to know if orientation changes when we scale
+      def changes_orientation?
+        autorotate? && [90, 270].include?(@movie.rotation)
+      end
+
+      def autorotate?
+        @transcoder_options[:autorotate] && @movie.rotation && @movie.rotation != 0
+      end
+
+    end
+  end
+end

--- a/lib/ffmpeg/transcoders/scaler.rb
+++ b/lib/ffmpeg/transcoders/scaler.rb
@@ -10,10 +10,21 @@ module FFMPEG
         
         def apply_preserve_aspect_ratio(change_orientation=false)
           return unless preserve_aspect_ratio?
+
           side = @transcoder_options[:preserve_aspect_ratio].to_s
           size = @raw_options.send(side)
           side = invert_side(side) if change_orientation            
+
+          if @transcoder_options[:enlarge] == false
+            original_size = @movie.send(side)
+            size = original_size if original_size < size
+          end
+
           set_new_resolution(side, size)
+        end
+
+        def calculate_size(side)
+          
         end
 
         def set_new_resolution(side, size)

--- a/lib/ffmpeg/transcoders/scaler.rb
+++ b/lib/ffmpeg/transcoders/scaler.rb
@@ -1,0 +1,45 @@
+module FFMPEG
+  module Transcoders
+    module Scaler
+      private
+
+        def preserve_aspect_ratio?
+          @movie.calculated_aspect_ratio && 
+          %w(width height).include?(@transcoder_options[:preserve_aspect_ratio].to_s)
+        end
+        
+        def apply_preserve_aspect_ratio(change_orientation=false)
+          return unless preserve_aspect_ratio?
+          side = @transcoder_options[:preserve_aspect_ratio].to_s
+          size = @raw_options.send(side)
+          side = invert_side(side) if change_orientation            
+          set_new_resolution(side, size)
+        end
+
+        def set_new_resolution(side, size)
+          case side
+          when "width"
+            new_height = size / @movie.calculated_aspect_ratio
+            new_height = evenize(new_height)
+            @raw_options[:resolution] = "#{size}x#{new_height}"
+          when "height"
+            new_width = size * @movie.calculated_aspect_ratio
+            new_width = evenize(new_width)
+            @raw_options[:resolution] = "#{new_width}x#{size}"
+          end
+        end
+
+        def invert_side(side)
+          side == 'height' ? 'width' : 'height'
+        end
+        
+        # ffmpeg requires full, even numbers for its resolution string -- this method ensures that
+        def evenize(number)
+          number = number.ceil.even? ? number.ceil : number.floor
+          number.odd? ? number += 1 : number # needed if new_height ended up with no decimals in the first place
+        end
+
+    end
+  end
+end
+

--- a/lib/ffmpeg/transcoders/scaler.rb
+++ b/lib/ffmpeg/transcoders/scaler.rb
@@ -8,11 +8,29 @@ module FFMPEG
           %w(width height).include?(@transcoder_options[:preserve_aspect_ratio].to_s)
         end
         
+        # Scaling with autorotation 
+        #
+        # If scaled in conjuction with autorotation 
+        # and the rotation results in an orientation change
+        # we must "invert" the side that is preserved
+        # as scaling takes place prior to rotation
+        #
+        # Example: 
+        #
+        # Original: resolution => 640x480, rotation => 90 
+        # Requested: resolution => 660x2, preserved_aspect_ration => :width, autorotate => true
+        #
+        # => the orientation will change from landscape to portrait
+        # => we have to invert the preserved_aspect_ration => :height
+        #
+        # Output: resolution => 660x880
+        # 
         def apply_preserve_aspect_ratio(change_orientation=false)
           return unless preserve_aspect_ratio?
 
           side = @transcoder_options[:preserve_aspect_ratio].to_s
           size = @raw_options.send(side)
+
           side = invert_side(side) if change_orientation            
 
           if @transcoder_options[:enlarge] == false
@@ -21,10 +39,6 @@ module FFMPEG
           end
 
           set_new_resolution(side, size)
-        end
-
-        def calculate_size(side)
-          
         end
 
         def set_new_resolution(side, size)

--- a/spec/ffmpeg/encoding_options_spec.rb
+++ b/spec/ffmpeg/encoding_options_spec.rb
@@ -130,6 +130,17 @@ module FFMPEG
       it "should ignore options with nil value" do
         EncodingOptions.new(:video_codec => "libx264", :frame_rate => nil).to_s.should == "-vcodec libx264 "
       end
+
+      it "should convert metadata" do
+        setting = 's:v:0 rotate=0'
+        EncodingOptions.new(:metadata => setting).to_s.should == "-metadata:#{setting}"
+      end
+
+      it "should convert video filter" do
+        setting = 'transpose=1'
+        EncodingOptions.new(:video_filter => setting).to_s.should == "-vf #{setting}"
+      end
+
     end
   end
 end

--- a/spec/ffmpeg/transcoder_spec.rb
+++ b/spec/ffmpeg/transcoder_spec.rb
@@ -113,7 +113,7 @@ module FFMPEG
           encoded = Transcoder.new(@movie, "#{tmp_path}/preserved_aspect.mp4", @options, special_options).run
           encoded.resolution.should == "426x240"
         end
-        
+
         it "should not be used if original resolution is undeterminable" do
           @movie.should_receive(:calculated_aspect_ratio).and_return(nil)
           special_options = {:preserve_aspect_ratio => :height}
@@ -129,6 +129,28 @@ module FFMPEG
           encoded = Transcoder.new(@movie, "#{tmp_path}/preserved_aspect.mp4", @options, special_options).run
           encoded.resolution.should == "320x260" # 320 / 1.234 should at first be rounded to 259
         end
+
+        context "enlarged scaling disabled" do
+
+          it "it works to shrink" do
+            @options = {:resolution => "160x120"}
+            special_options = {:preserve_aspect_ratio => :width, :enlarge => false}
+            encoded = Transcoder.new(@movie, "#{tmp_path}/preserved_aspect.mp4", @options, special_options).run
+            encoded.resolution.should == "160x90"
+          end
+
+          it "it does not to enlarge" do
+            special_options = {:preserve_aspect_ratio => :height, :enlarge => false}
+            # original resolution: "320x180"
+            # target resolution: "320x240"
+            # preserved target resolution: "426x240"
+            # expected resolution: "320x180", video may not be enlarged
+            original_resolution = @movie.resolution   
+            encoded = Transcoder.new(@movie, "#{tmp_path}/preserved_aspect.mp4", @options, special_options).run
+            encoded.resolution.should == original_resolution 
+          end
+        end
+        
       end
 
       it "should transcode the movie with String options" do
@@ -192,35 +214,56 @@ module FFMPEG
           @options = {}
         end
         it "shouldn't rotate when autorotate is false" do
-          special_options = {:autorotate => false}
-          encoded = Transcoder.new(@movie, "#{tmp_path}/autorotated.mp4", @options, special_options).run
+          transcoder_options = {:autorotate => false}
+          encoded = Transcoder.new(@movie, "#{tmp_path}/autorotated.mp4", @options, transcoder_options).run
           encoded.resolution.should == @movie.resolution
         end
         it "shouldn't rotate when move is not rotated" do
           @movie = Movie.new("#{fixture_path}/movies/awesome_widescreen.mov")
-          special_options = {:autorotate => true}
-          encoded = Transcoder.new(@movie, "#{tmp_path}/autorotated.mp4", @options, special_options).run
+          transcoder_options = {:autorotate => true}
+          encoded = Transcoder.new(@movie, "#{tmp_path}/autorotated.mp4", @options, transcoder_options).run
           encoded.resolution.should == @movie.resolution
         end
         it "should reset the autorotate metadata" do
-          special_options = {:autorotate => true}
-          encoded = Transcoder.new(@movie, "#{tmp_path}/autorotated.mp4", @options, special_options).run
+          transcoder_options = {:autorotate => true}
+          encoded = Transcoder.new(@movie, "#{tmp_path}/autorotated.mp4", @options, transcoder_options).run
           @movie.rotation.should_not == nil
           encoded.rotation.should == nil
         end
         it "should rotate when move is rotated and autorotate is true" do
-          special_options = {:autorotate => true}
-          encoded = Transcoder.new(@movie, "#{tmp_path}/autorotated.mp4", @options, special_options).run
+          transcoder_options = {:autorotate => true}
+          encoded = Transcoder.new(@movie, "#{tmp_path}/autorotated.mp4", @options, transcoder_options).run
           rotated_resolution = @movie.resolution.split('x').reverse.join('x')
           encoded.resolution.should == rotated_resolution
         end
         it "inverts aspect ratio when autorotating" do
+          # by default also enlarges the video
           @options = {:resolution => "660x42"}
-          special_options = {:autorotate => true, :preserve_aspect_ratio => :width}
-          encoded = Transcoder.new(@movie, "#{tmp_path}/autorotated.mp4", @options, special_options).run
+          transcoder_options = {:autorotate => true, :preserve_aspect_ratio => :width}
+          encoded = Transcoder.new(@movie, "#{tmp_path}/autorotated.mp4", @options, transcoder_options).run
           rotated_resolution = @movie.resolution.split('x').reverse.join('x')
           encoded.width.should == 660
           encoded.height.should == 880
+        end
+        context "enlarged scaling disabled" do
+
+          it "it works to shrink" do
+            # original resolution: 640x480
+            # original rotated resolution: 480x640
+            # target resolution 240x42
+            # expected resoltuion: 240x320
+            @options = {:resolution => "240x42"}
+            special_options = {:autorotate => true, :preserve_aspect_ratio => :width, :enlarge => false}
+            encoded = Transcoder.new(@movie, "#{tmp_path}/preserved_aspect.mp4", @options, special_options).run
+            encoded.resolution.should == "240x320"
+          end
+
+          it "it does not enlarge" do
+            @options = {:resolution => "660x42"}
+            transcoder_options = {:autorotate => true, :preserve_aspect_ratio => :width, :enlarge => false}
+            encoded = Transcoder.new(@movie, "#{tmp_path}/autorotated.mp4", @options, transcoder_options).run
+            rotated_resolution = "480x640"
+          end
         end
       end
     end

--- a/streamio-ffmpeg.gemspec
+++ b/streamio-ffmpeg.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.homepage    = "http://github.com/torial/streamio-ffmpeg"
   s.summary     = "Reads metadata and transcodes movies."
   s.description = "Simple yet powerful wrapper around ffmpeg to get metadata from movies and do transcoding."
+  s.license     = "MIT"
 
   s.add_development_dependency("rspec", "~> 2.7")
   s.add_development_dependency("rake", "~> 0.9.2")

--- a/streamio-ffmpeg.gemspec
+++ b/streamio-ffmpeg.gemspec
@@ -5,14 +5,14 @@ $:.unshift lib unless $:.include?(lib)
 require "ffmpeg/version"
 
 Gem::Specification.new do |s|
-  s.name        = "streamio-ffmpeg"
+  s.name        = "brainsome_streamio-ffmpeg"
   s.version     = FFMPEG::VERSION
-  s.authors     = ["David Backeus"]
-  s.email       = ["david@streamio.se"]
-  s.homepage    = "http://github.com/streamio/streamio-ffmpeg"
+  s.authors     = ["David Backeus", "Brainsome-Developers"]
+  s.email       = ["david@streamio.se", nil]
+  s.homepage    = "http://github.com/torial/streamio-ffmpeg"
   s.summary     = "Reads metadata and transcodes movies."
   s.description = "Simple yet powerful wrapper around ffmpeg to get metadata from movies and do transcoding."
-  
+
   s.add_development_dependency("rspec", "~> 2.7")
   s.add_development_dependency("rake", "~> 0.9.2")
 

--- a/streamio-ffmpeg.gemspec
+++ b/streamio-ffmpeg.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.version     = FFMPEG::VERSION
   s.authors     = ["David Backeus", "Brainsome-Developers"]
   s.email       = ["david@streamio.se", nil]
-  s.homepage    = "http://github.com/torial/streamio-ffmpeg"
+  s.homepage    = "https://github.com/brainsome-de/streamio-ffmpeg"
   s.summary     = "Reads metadata and transcodes movies."
   s.description = "Simple yet powerful wrapper around ffmpeg to get metadata from movies and do transcoding."
   s.license     = "MIT"


### PR DESCRIPTION
Hi,

first of all, thanks for your Ruby ffmpeg library! We're using it in production at beta.torial.com and it helped us a lot to simplify our video conversion code.

As you probably know, videos from mobile devices are often displayed "sideways" or upside down in the browser, since the browser doesn't evaluate the video's rotation metadata. So we have streamio-ffmpeg do that :-) and rotate the video accordingly. Both the #screenshot and the #transcode command support this. 

We introduced some architectural changes since just "patching it in" got a bit messy, but did so in a TDD way, so everything should work as it did before. We have had the code running in production for 1-2 months now without issues; keep in mind our site is still low volume, though.

If you feel this would be a useful addition, go ahead and pull the changes in! We'd be very happy about that, of course.

Cheers,
Phillip
