### PR TITLE
Added container information to FFMPEG::Movie

### DIFF
--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -5,7 +5,8 @@ module FFMPEG
     attr_reader :path, :duration, :time, :bitrate, :rotation, :creation_time
     attr_reader :video_stream, :video_codec, :video_bitrate, :colorspace, :resolution, :dar
     attr_reader :audio_stream, :audio_codec, :audio_bitrate, :audio_sample_rate
-    
+    attr_reader :container
+
     def initialize(path)
       raise Errno::ENOENT, "the file '#{path}' does not exist" unless File.exists?(path)
       
@@ -50,6 +51,9 @@ module FFMPEG
         @audio_bitrate = audio_bitrate =~ %r(\A(\d+) kb/s\Z) ? $1.to_i : nil
         @audio_sample_rate = audio_sample_rate[/\d*/].to_i
       end
+
+      output[/Input #\d+, (.*?),\s/]
+      @container = $1
       
       @invalid = true if @video_stream.to_s.empty? && @audio_stream.to_s.empty?
       @invalid = true if output.include?("is not supported")

--- a/spec/ffmpeg/movie_spec.rb
+++ b/spec/ffmpeg/movie_spec.rb
@@ -229,6 +229,10 @@ module FFMPEG
         it "should know the file size" do
           @movie.size.should == 455546
         end
+
+        it "should know the container format" do
+          @movie.container.should =~ /mov/
+        end
       end
     end
 


### PR DESCRIPTION
I needed to extract the container information from ffmpeg, and since the gem didn't already extract it, I went ahead and implemented it.
This is not a duplicate pull request, as the other one was closed for having commits from other stuff.

Thanks,
Pedro
