### PR TITLE
Alter force_encoding from ISO-8859-1 to UTF-8

### DIFF
--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -121,7 +121,7 @@ module FFMPEG
     def fix_encoding(output)
       output[/test/]
     rescue ArgumentError
-      output.force_encoding("ISO-8859-1")
+      output.force_encoding("UTF-8")
     end
   end
 end


### PR DESCRIPTION
Dears, 
I have change transcoder#fix_encoding output encoding from **ISO-8859-1** to **UTF-8** while handling video with non English meta(say like Chinese). 
My Video Meta as follow:

```
Metadata:
    major_brand     : isom
    minor_version   : 1
    compatible_brands: isom
    creation_time   : 2012-09-14 00:04:01
    media_type      : 0
    title           : Peter Norvig：容纳十万人的教室
    artist          : TED
    date            : 2012
    album           : TEDTalks
    comment         : Translated by: Hugo Zhang
                    : Reviewed by: Si Xie
                    : To learn more about this speaker, find other TEDTalks, and subscribe to this Podcast series, visit www.TED.com
                    : Feedback: contact@ted.com
    genre           : Podcast
    description     : 2011年秋季，Peter Norvig和Sebastian Thrun在斯坦福大学开办了一个由175在校学生出席的的“人工智能”课程——这同时还有超过十万的学生通过互动直
播来观看这个网络课程。他将与我们分享从这个
```
