### PR TITLE
Support for reading/writing container metadata

### DIFF
--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -5,7 +5,7 @@ module FFMPEG
     attr_reader :path, :duration, :time, :bitrate, :rotation, :creation_time
     attr_reader :video_stream, :video_codec, :video_bitrate, :colorspace, :resolution, :dar
     attr_reader :audio_stream, :audio_codec, :audio_bitrate, :audio_sample_rate
-    attr_reader :container
+    attr_reader :container, :meta
 
     def initialize(path)
       raise Errno::ENOENT, "the file '#{path}' does not exist" unless File.exists?(path)
@@ -20,6 +20,9 @@ module FFMPEG
 
       output[/Input \#\d+\,\s*(\S+),\s*from/]
       @container = $1
+
+      output[/Metadata:(.*)Duration:/m]
+      @meta = parse_metadata($1)
 
       output[/Duration: (\d{2}):(\d{2}):(\d{2}\.\d{2})/]
       @duration = ($1.to_i*60*60) + ($2.to_i*60) + $3.to_f
@@ -118,6 +121,12 @@ module FFMPEG
       output[/test/] # Running a regexp on the string throws error if it's not UTF-8
     rescue ArgumentError
       output.force_encoding("ISO-8859-1")
+    end
+
+    def parse_metadata(string)
+      Hash[string.strip.split("\n").collect { |obj| obj.split(/[^\d]:[^\d]/).collect(&:strip) }]
+    rescue
+      nil
     end
   end
 end

--- a/spec/ffmpeg/encoding_options_spec.rb
+++ b/spec/ffmpeg/encoding_options_spec.rb
@@ -138,6 +138,23 @@ module FFMPEG
       it "should convert x264 preset" do
         EncodingOptions.new(x264_preset: "slow").to_s.should == "-preset slow"
       end
+
+      it "should convert clear existing metadata flag" do
+        EncodingOptions.new(clear_existing_metadata: true).to_s.should == "-map_metadata -1"
+      end
+
+      it "should convert metadata given a String" do
+        EncodingOptions.new(metadata: "Application=\"SomeApp 1.0\"").to_s.should == "-metadata Application=\"SomeApp 1.0\""
+      end
+
+      it "should convert metadata given a Hash" do
+        metadata_options = { application: 'SomeApp 1.0', author: 'Some Guy' }
+        EncodingOptions.new(metadata: metadata_options).to_s.should == "-metadata application=\"SomeApp 1.0\" -metadata author=\"Some Guy\""
+      end
+
+      it "should put the metadata parameters in order, prioritizing :clear_existing_metadata first" do
+        EncodingOptions.new(metadata: { application: "SomeApp 1.0" }, clear_existing_metadata: true).to_s.should == "-map_metadata -1 -metadata application=\"SomeApp 1.0\""
+      end
     end
   end
 end

--- a/spec/ffmpeg/movie_spec.rb
+++ b/spec/ffmpeg/movie_spec.rb
@@ -233,6 +233,12 @@ module FFMPEG
         it "should know the container" do
           @movie.container.should == "mov,mp4,m4a,3gp,3g2,mj2"
         end
+
+        it "should parse the container metadata" do
+          @movie.meta.size.should == 4
+          @movie.meta.has_key?('major_brand').should == true
+          @movie.meta['major_brand'].should == "qt"
+        end
       end
     end
 


### PR DESCRIPTION
Adds the `:clear_existing_metadata` option which, when set to true,
will add flags to ffmpeg to remove existing metadata on the media
container.

Adds the `:metadata` option which accepts either a **String** containing
the `-metadata` argument you wish to set on the container, or a **Hash**
of key-value pairs which will be set on the container.

``` ruby
movie = FFMPEG::Movie.new('path_to/movie.mov')
movie.transcode('path_to/movie.mp4', {
  clear_existing_metadata: true,
  metadata: {
    creation_time: Time.local(2005, 03, 04, 14, 30, 00),
    'Application' => 'SomeApp 1.0'
  }
})
```

**...or...**

``` ruby
movie = FFMPEG::Movie.new('path_to/movie.mov')
movie.transcode('path_to/movie.mp4', {
  clear_existing_metadata: true,
  metadata: 'Application="SomeApp 1.0"'
})
```

Tests included.

Not sure if anyone else would find this useful, but figured I might as well contribute.
