### PR TITLE
Change escaping method from Shellwords.escape to simply quoted strings, ...

### DIFF
--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -13,7 +13,7 @@ module FFMPEG
       @path = path
 
       # ffmpeg will output to stderr
-      command = "#{FFMPEG.ffmpeg_binary} -i #{Shellwords.escape(path)}"
+      command = "#{FFMPEG.ffmpeg_binary} -i \"#{path}\""
       output = Open3.popen3(command) { |stdin, stdout, stderr| stderr.read }
 
       fix_encoding(output)

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -54,7 +54,7 @@ module FFMPEG
     private
     # frame= 4855 fps= 46 q=31.0 size=   45306kB time=00:02:42.28 bitrate=2287.0kbits/
     def transcode_movie
-      @command = "#{FFMPEG.ffmpeg_binary} -y -i #{Shellwords.escape(@movie.path)} #{@raw_options} #{Shellwords.escape(@output_file)}"
+      @command = "#{FFMPEG.ffmpeg_binary} -y -i \"#{@movie.path}\" #{@raw_options} \"#{@output_file}\""
       FFMPEG.logger.info("Running transcoding...\n#{@command}\n")
       @output = ""
 


### PR DESCRIPTION
Using `Shellwords.escape` introduces a bug on Windows, where methods like `transcode` and `screenshot` will fail if there are spaces in either the input or output filenames. `Shellwords.escape` uses `\` as its escape character, but on Windows `\` is the folder delimiter in path names, so ffmpeg is only ever passed the first word in the filename (the caret `^` is the Windows command-line escape character). Switching to a simple quoted string lets those method calls work on any OS.

