### PR TITLE
Fix for #81 (start time offset seeking slow)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Give custom command line options with a string.
 movie.transcode("movie.mp4", "-ac aac -vc libx264 -ac 2 ...")
 ```
 
-Use the EncodingOptions parser for humanly readable transcoding options. Below you'll find most of the supported options. Note that the :custom key will be used as is without modification so use it for any tricky business you might need.
+Use the EncodingOptions parser for humanly readable transcoding options. Below you'll find most of the supported options. Note that the :custom and :custom_input keys will be used as is without modification, so use them for any tricky business you might need.  :custom_input appears before the -i (indicating input options), :custom appears after (indicating output options).
 
 ``` ruby
 options = {video_codec: "libx264", frame_rate: 10, resolution: "320x240", video_bitrate: 300, video_bitrate_tolerance: 100,
@@ -88,6 +88,7 @@ options = {video_codec: "libx264", frame_rate: 10, resolution: "320x240", video_
            x264_vprofile: "high", x264_preset: "slow",
            audio_codec: "libfaac", audio_bitrate: 32, audio_sample_rate: 22050, audio_channels: 1,
            threads: 2,
+           custom_input: "-ss 20",
            custom: "-vf crop=60:60:10:10"}
 movie.transcode("movie.mp4", options)
 ```

--- a/lib/ffmpeg/encoding_options.rb
+++ b/lib/ffmpeg/encoding_options.rb
@@ -5,16 +5,22 @@ module FFMPEG
     end
 
     def to_s
+      to_params("")
+    end
+
+    def to_params(input_param_string="")
       params = collect do |key, value|
         send("convert_#{key}", value) if value && supports_option?(key)
       end
 
+      # seek times should go before the input option to trigger faster input seeking
       # codecs should go before the presets so that the files will be matched successfully
       # all other parameters go after so that we can override whatever is in the preset
+      seeks = params.select { |p| p =~ /\-ss/ }
       codecs = params.select { |p| p =~ /codec/ }
       presets = params.select { |p| p =~ /\-.pre/ }
-      other = params - codecs - presets
-      params = codecs + presets + other
+      other = params - seeks - codecs - presets
+      params = seeks + [input_param_string] + codecs + presets + other
 
       params_string = params.join(" ")
       params_string << " #{convert_aspect(calculate_aspect)}" if calculate_aspect?

--- a/lib/ffmpeg/encoding_options.rb
+++ b/lib/ffmpeg/encoding_options.rb
@@ -22,7 +22,7 @@ module FFMPEG
     end
 
     def to_input_options
-      self[:input_custom] || ""
+      self[:custom_input] || ""
     end
 
     def width
@@ -163,9 +163,9 @@ module FFMPEG
 
     # Don't include custom input options (which must appear before -i) with
     # the output options (which appear after -i).  By leaving this method
-    # defined as returning an empty string, the `:input_custom` options won't
+    # defined as returning an empty string, the `:custom_input` options won't
     # accidentally get duplicated as output options.
-    def convert_input_custom(value)
+    def convert_custom_input(value)
       ""
     end
 

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -54,8 +54,8 @@ module FFMPEG
     private
     # frame= 4855 fps= 46 q=31.0 size=   45306kB time=00:02:42.28 bitrate=2287.0kbits/
     def transcode_movie
-      @command = if @raw_options.respond_to?(:to_params)
-        "#{FFMPEG.ffmpeg_binary} -y #{@raw_options.to_params("-i #{Shellwords.escape(@movie.path)}")} #{Shellwords.escape(@output_file)}"
+      @command = if @raw_options.respond_to?(:to_input_options)
+        "#{FFMPEG.ffmpeg_binary} -y #{@raw_options.to_input_options} -i #{Shellwords.escape(@movie.path)} #{@raw_options} #{Shellwords.escape(@output_file)}"
       else
         "#{FFMPEG.ffmpeg_binary} -y -i #{Shellwords.escape(@movie.path)} #{@raw_options} #{Shellwords.escape(@output_file)}"
       end

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -54,7 +54,11 @@ module FFMPEG
     private
     # frame= 4855 fps= 46 q=31.0 size=   45306kB time=00:02:42.28 bitrate=2287.0kbits/
     def transcode_movie
-      @command = "#{FFMPEG.ffmpeg_binary} -y -i #{Shellwords.escape(@movie.path)} #{@raw_options} #{Shellwords.escape(@output_file)}"
+      @command = if @raw_options.respond_to?(:to_params)
+        "#{FFMPEG.ffmpeg_binary} -y #{@raw_options.to_params("-i #{Shellwords.escape(@movie.path)}")} #{Shellwords.escape(@output_file)}"
+      else
+        "#{FFMPEG.ffmpeg_binary} -y -i #{Shellwords.escape(@movie.path)} #{@raw_options} #{Shellwords.escape(@output_file)}"
+      end
       FFMPEG.logger.info("Running transcoding...\n#{@command}\n")
       @output = ""
 


### PR DESCRIPTION
Fix for #81 (start time offset seeking slow)

Added a `:custom_input` param that allows specifying input options, which must appear before the `-i` in the ffmpeg command line.

Passing `custom_input: "-ss 20"` will generate `ffmpeg -ss 20 -i file.mp4 ...` instead of `ffmpeg -i file.mp4 -ss 20 ...`.

Moving the `-ss` before the `-i` tells ffmpeg to use fast input seeking rather than slow output seeking (see https://trac.ffmpeg.org/wiki/Seeking).  End-of-video screenshots that took minutes on my computer are now almost instantaneous (because it skips over the video rather than rendering & discarding it).