### PR TITLE
handle invalid creation_time, compatibility with recent ffmpeg version

### DIFF
--- a/lib/ffmpeg/encoding_options.rb
+++ b/lib/ffmpeg/encoding_options.rb
@@ -140,6 +140,10 @@ module FFMPEG
       "-i #{value}"
     end
 
+    def convert_target(value)
+      "-target #{value}"
+    end
+
     def convert_watermark_filter(value)
       case value[:position].to_s
       when "LT"

--- a/spec/ffmpeg/movie_spec.rb
+++ b/spec/ffmpeg/movie_spec.rb
@@ -233,7 +233,7 @@ module FFMPEG
         end
 
         it "should parse video stream information" do
-          @movie.video_stream.should == "h264 (Main) (avc1 / 0x31637661), yuv420p, 640x480 [SAR 1:1 DAR 4:3], 371 kb/s, 16.75 fps, 600 tbr, 600 tbn, 1200 tbc"
+          @movie.video_stream.should =~ /h264 \(Main\) \(avc1 \/ 0x31637661\), yuv420p(\(tv, bt709\))?, 640x480 \[SAR 1:1 DAR 4:3\], 371 kb\/s, 16.75 fps, 600 tbr, 600 tbn, 1200 tbc/
         end
 
         it "should know the video codec" do
@@ -241,7 +241,7 @@ module FFMPEG
         end
 
         it "should know the colorspace" do
-          @movie.colorspace.should == "yuv420p"
+          @movie.colorspace.should =~ /yuv420p(\(tv, bt709\))?/
         end
 
         it "should know the resolution" do
@@ -262,7 +262,7 @@ module FFMPEG
         end
 
         it "should parse audio stream information" do
-          @movie.audio_stream.should == "aac (mp4a / 0x6134706D), 44100 Hz, stereo, fltp, 75 kb/s"
+          @movie.audio_stream.should =~ /aac (\(LC\))? \(mp4a \/ 0x6134706D\), 44100 Hz, stereo, fltp, 75 kb\/s( \(default\))?/
         end
 
         it "should know the audio codec" do

--- a/spec/ffmpeg/transcoder_spec.rb
+++ b/spec/ffmpeg/transcoder_spec.rb
@@ -58,8 +58,8 @@ module FFMPEG
           end
 
           it "should still work" do
-            encoded = Transcoder.new(movie, "#{tmp_path}/awesome.mpg").run
-            encoded.resolution.should == "640x480"
+            encoded = Transcoder.new(movie, "#{tmp_path}/awesome.mpg", { target: "ntsc-dvd" }).run
+            encoded.resolution.should == "720x480"
           end
 
           after { Transcoder.timeout = @original_timeout }


### PR DESCRIPTION
- Rescue error when parsing an invalid date in the video metadata fails
- add target parameter to transcode mpg video
- adjust regexes in spec to match the output of a recent version of ffmpeg

Yet to validate if this is compatible with an old version of ffmpeg.