### PR TITLE
Update tests to use rspec 3.4

### DIFF
--- a/spec/ffmpeg/encoding_options_spec.rb
+++ b/spec/ffmpeg/encoding_options_spec.rb
@@ -4,124 +4,124 @@ module FFMPEG
   describe EncodingOptions do
     describe "ffmpeg arguments conversion" do
       it "should convert video codec" do
-        EncodingOptions.new(video_codec: "libx264").to_s.should == "-vcodec libx264"
+        expect(EncodingOptions.new(video_codec: "libx264").to_s).to eq("-vcodec libx264")
       end
 
       it "should know the width from the resolution or be nil" do
-        EncodingOptions.new(resolution: "320x240").width.should == 320
-        EncodingOptions.new.width.should be_nil
+        expect(EncodingOptions.new(resolution: "320x240").width).to eq(320)
+        expect(EncodingOptions.new.width).to be_nil
       end
 
       it "should know the height from the resolution or be nil" do
-        EncodingOptions.new(resolution: "320x240").height.should == 240
-        EncodingOptions.new.height.should be_nil
+        expect(EncodingOptions.new(resolution: "320x240").height).to eq(240)
+        expect(EncodingOptions.new.height).to be_nil
       end
 
       it "should convert frame rate" do
-        EncodingOptions.new(frame_rate: 29.9).to_s.should == "-r 29.9"
+        expect(EncodingOptions.new(frame_rate: 29.9).to_s).to eq("-r 29.9")
       end
 
       it "should convert the resolution" do
-        EncodingOptions.new(resolution: "640x480").to_s.should include("-s 640x480")
+        expect(EncodingOptions.new(resolution: "640x480").to_s).to include("-s 640x480")
       end
 
       it "should add calculated aspect ratio" do
-        EncodingOptions.new(resolution: "640x480").to_s.should include("-aspect 1.3333333")
-        EncodingOptions.new(resolution: "640x360").to_s.should include("-aspect 1.7777777777777")
+        expect(EncodingOptions.new(resolution: "640x480").to_s).to include("-aspect 1.3333333")
+        expect(EncodingOptions.new(resolution: "640x360").to_s).to include("-aspect 1.7777777777777")
       end
 
       it "should use specified aspect ratio if given" do
         output = EncodingOptions.new(resolution: "640x480", aspect: 1.77777777777778).to_s
-        output.should include("-s 640x480")
-        output.should include("-aspect 1.77777777777778")
+        expect(output).to include("-s 640x480")
+        expect(output).to include("-aspect 1.77777777777778")
       end
 
       it "should convert video bitrate" do
-        EncodingOptions.new(video_bitrate: "600k").to_s.should == "-b:v 600k"
+        expect(EncodingOptions.new(video_bitrate: "600k").to_s).to eq("-b:v 600k")
       end
 
       it "should use k unit for video bitrate" do
-        EncodingOptions.new(video_bitrate: 600).to_s.should == "-b:v 600k"
+        expect(EncodingOptions.new(video_bitrate: 600).to_s).to eq("-b:v 600k")
       end
 
       it "should convert audio codec" do
-        EncodingOptions.new(audio_codec: "aac").to_s.should == "-acodec aac"
+        expect(EncodingOptions.new(audio_codec: "aac").to_s).to eq("-acodec aac")
       end
 
       it "should convert audio bitrate" do
-        EncodingOptions.new(audio_bitrate: "128k").to_s.should == "-b:a 128k"
+        expect(EncodingOptions.new(audio_bitrate: "128k").to_s).to eq("-b:a 128k")
       end
 
       it "should use k unit for audio bitrate" do
-        EncodingOptions.new(audio_bitrate: 128).to_s.should == "-b:a 128k"
+        expect(EncodingOptions.new(audio_bitrate: 128).to_s).to eq("-b:a 128k")
       end
 
       it "should convert audio sample rate" do
-        EncodingOptions.new(audio_sample_rate: 44100).to_s.should == "-ar 44100"
+        expect(EncodingOptions.new(audio_sample_rate: 44100).to_s).to eq("-ar 44100")
       end
 
       it "should convert audio channels" do
-        EncodingOptions.new(audio_channels: 2).to_s.should == "-ac 2"
+        expect(EncodingOptions.new(audio_channels: 2).to_s).to eq("-ac 2")
       end
 
       it "should convert maximum video bitrate" do
-        EncodingOptions.new(video_max_bitrate: 600).to_s.should == "-maxrate 600k"
+        expect(EncodingOptions.new(video_max_bitrate: 600).to_s).to eq("-maxrate 600k")
       end
 
       it "should convert mininimum video bitrate" do
-        EncodingOptions.new(video_min_bitrate: 600).to_s.should == "-minrate 600k"
+        expect(EncodingOptions.new(video_min_bitrate: 600).to_s).to eq("-minrate 600k")
       end
 
       it "should convert video bitrate tolerance" do
-        EncodingOptions.new(video_bitrate_tolerance: 100).to_s.should == "-bt 100k"
+        expect(EncodingOptions.new(video_bitrate_tolerance: 100).to_s).to eq("-bt 100k")
       end
 
       it "should convert buffer size" do
-        EncodingOptions.new(buffer_size: 2000).to_s.should == "-bufsize 2000k"
+        expect(EncodingOptions.new(buffer_size: 2000).to_s).to eq("-bufsize 2000k")
       end
 
       it "should convert threads" do
-        EncodingOptions.new(threads: 2).to_s.should == "-threads 2"
+        expect(EncodingOptions.new(threads: 2).to_s).to eq("-threads 2")
       end
 
       it "should convert duration" do
-        EncodingOptions.new(duration: 30).to_s.should == "-t 30"
+        expect(EncodingOptions.new(duration: 30).to_s).to eq("-t 30")
       end
 
       it "should convert target" do
-        EncodingOptions.new(target: 'ntsc-vcd').to_s.should == "-target ntsc-vcd"
+        expect(EncodingOptions.new(target: 'ntsc-vcd').to_s).to eq("-target ntsc-vcd")
       end
 
       it "should convert keyframe interval" do
-        EncodingOptions.new(keyframe_interval: 60).to_s.should == "-g 60"
+        expect(EncodingOptions.new(keyframe_interval: 60).to_s).to eq("-g 60")
       end
 
       it "should convert video preset" do
-        EncodingOptions.new(video_preset: "max").to_s.should == "-vpre max"
+        expect(EncodingOptions.new(video_preset: "max").to_s).to eq("-vpre max")
       end
 
       it "should convert audio preset" do
-        EncodingOptions.new(audio_preset: "max").to_s.should == "-apre max"
+        expect(EncodingOptions.new(audio_preset: "max").to_s).to eq("-apre max")
       end
 
       it "should convert file preset" do
-        EncodingOptions.new(file_preset: "max.ffpreset").to_s.should == "-fpre max.ffpreset"
+        expect(EncodingOptions.new(file_preset: "max.ffpreset").to_s).to eq("-fpre max.ffpreset")
       end
 
       it "should specify seek time" do
-        EncodingOptions.new(seek_time: 1).to_s.should == "-ss 1"
+        expect(EncodingOptions.new(seek_time: 1).to_s).to eq("-ss 1")
       end
 
       it "should specify default screenshot parameters" do
-        EncodingOptions.new(screenshot: true).to_s.should == "-vframes 1 -f image2"
+        expect(EncodingOptions.new(screenshot: true).to_s).to eq("-vframes 1 -f image2")
       end
 
       it 'should specify screenshot parameters when using -vframes' do
-        EncodingOptions.new(screenshot: true, vframes: 123).to_s.should == '-f image2 -vframes 123'
+        expect(EncodingOptions.new(screenshot: true, vframes: 123).to_s).to eq('-f image2 -vframes 123')
       end
 
       it 'should specify screenshot parameters when using video quality -v:q' do
-        EncodingOptions.new(screenshot: true, vframes: 123, quality: 3).to_s.should == '-f image2 -vframes 123 -q:v 3'
+        expect(EncodingOptions.new(screenshot: true, vframes: 123, quality: 3).to_s).to eq('-f image2 -vframes 123 -q:v 3')
       end
 
       it "should put the parameters in order of codecs, presets, others" do
@@ -131,28 +131,28 @@ module FFMPEG
         opts[:video_preset] = "normal"
 
         converted = EncodingOptions.new(opts).to_s
-        converted.should == "-vcodec libx264 -vpre normal -r 25"
+        expect(converted).to eq("-vcodec libx264 -vpre normal -r 25")
       end
 
       it "should convert a lot of them simultaneously" do
         converted = EncodingOptions.new(video_codec: "libx264", audio_codec: "aac", video_bitrate: "1000k").to_s
-        converted.should match(/-acodec aac/)
+        expect(converted).to match(/-acodec aac/)
       end
 
       it "should ignore options with nil value" do
-        EncodingOptions.new(video_codec: "libx264", frame_rate: nil).to_s.should == "-vcodec libx264 "
+        expect(EncodingOptions.new(video_codec: "libx264", frame_rate: nil).to_s).to eq("-vcodec libx264 ")
       end
 
       it "should convert x264 vprofile" do
-        EncodingOptions.new(x264_vprofile: "high").to_s.should == "-vprofile high"
+        expect(EncodingOptions.new(x264_vprofile: "high").to_s).to eq("-vprofile high")
       end
 
       it "should convert x264 preset" do
-        EncodingOptions.new(x264_preset: "slow").to_s.should == "-preset slow"
+        expect(EncodingOptions.new(x264_preset: "slow").to_s).to eq("-preset slow")
       end
 
       it "should specify input watermark file" do
-        EncodingOptions.new(watermark: "watermark.png").to_s.should == "-i watermark.png"
+        expect(EncodingOptions.new(watermark: "watermark.png").to_s).to eq("-i watermark.png")
       end
 
       it "should specify watermark position at left top corner" do
@@ -160,7 +160,7 @@ module FFMPEG
         opts[:resolution] = "640x480"
         opts[:watermark_filter] = { position: "LT", padding_x: 10, padding_y: 10 }
         converted = EncodingOptions.new(opts).to_s
-        converted.should include "-filter_complex 'scale=640x480,overlay=x=10:y=10'"
+        expect(converted).to include "-filter_complex 'scale=640x480,overlay=x=10:y=10'"
       end
 
       it "should specify watermark position at right top corner" do
@@ -168,7 +168,7 @@ module FFMPEG
         opts[:resolution] = "640x480"
         opts[:watermark_filter] = { position: "RT", padding_x: 10, padding_y: 10 }
         converted = EncodingOptions.new(opts).to_s
-        converted.should include "-filter_complex 'scale=640x480,overlay=x=main_w-overlay_w-10:y=10'"
+        expect(converted).to include "-filter_complex 'scale=640x480,overlay=x=main_w-overlay_w-10:y=10'"
       end
 
       it "should specify watermark position at left bottom corner" do
@@ -176,7 +176,7 @@ module FFMPEG
         opts[:resolution] = "640x480"
         opts[:watermark_filter] = { position: "LB", padding_x: 10, padding_y: 10 }
         converted = EncodingOptions.new(opts).to_s
-        converted.should include "-filter_complex 'scale=640x480,overlay=x=10:y=main_h-overlay_h-10'"
+        expect(converted).to include "-filter_complex 'scale=640x480,overlay=x=10:y=main_h-overlay_h-10'"
       end
 
       it "should specify watermark position at left bottom corner" do
@@ -184,7 +184,7 @@ module FFMPEG
         opts[:resolution] = "640x480"
         opts[:watermark_filter] = { position: "RB", padding_x: 10, padding_y: 10 }
         converted = EncodingOptions.new(opts).to_s
-        converted.should include "overlay=x=main_w-overlay_w-10:y=main_h-overlay_h-10'"
+        expect(converted).to include "overlay=x=main_w-overlay_w-10:y=main_h-overlay_h-10'"
       end
     end
   end

--- a/spec/ffmpeg/movie_spec.rb
+++ b/spec/ffmpeg/movie_spec.rb
@@ -5,7 +5,7 @@ module FFMPEG
     describe "initializing" do
       let(:fake_output) { StringIO.new(File.read("#{fixture_path}/outputs/#{fixture_file}")) }
       let(:movie) do
-        Open3.stub(:popen3).and_yield(nil, nil, fake_output)
+        allow(Open3).to receive(:popen3).and_yield(nil, nil, fake_output)
         Movie.new(__FILE__)
       end
 
@@ -32,23 +32,23 @@ module FFMPEG
         end
 
         it "should not be valid" do
-          movie.should_not be_valid
+          expect(movie).to_not be_valid
         end
 
         it "should have a duration of 0" do
-          movie.duration.should == 0
+          expect(movie.duration).to eq(0)
         end
 
         it "should have nil height" do
-          movie.height.should be_nil
+          expect(movie.height).to be_nil
         end
 
         it "should have nil width" do
-          movie.width.should be_nil
+          expect(movie.width).to be_nil
         end
 
         it "should have nil frame_rate" do
-          movie.frame_rate.should be_nil
+          expect(movie.frame_rate).to be_nil
         end
       end
 
@@ -56,7 +56,7 @@ module FFMPEG
         let(:movie) { Movie.new("#{fixture_path}/movies/empty.flv") }
 
         it "should not be valid" do
-          movie.should_not be_valid
+          expect(movie).to_not be_valid
         end
       end
 
@@ -64,11 +64,11 @@ module FFMPEG
         let(:movie) { Movie.new("#{fixture_path}/movies/ios_rotate0.mov") }
 
         it "should have correct rotation detected" do
-          movie.rotation.should == nil
+          expect(movie.rotation).to eq(nil)
         end
         it "should have untouched width and height" do
-          movie.width.should == 1920
-          movie.height.should == 1080
+          expect(movie.width).to eq(1920)
+          expect(movie.height).to eq(1080)
         end
       end
 
@@ -76,12 +76,12 @@ module FFMPEG
         let(:movie) { Movie.new("#{fixture_path}/movies/ios_rotate90.mov") }
 
         it "should have correct rotation detected" do
-          movie.rotation.should == 90
+          expect(movie.rotation).to eq(90)
         end
 
         it "should have switched width and height" do
-          movie.width.should == 1080
-          movie.height.should == 1920
+          expect(movie.width).to eq(1080)
+          expect(movie.height).to eq(1920)
         end
       end
 
@@ -89,11 +89,11 @@ module FFMPEG
         let(:movie) { Movie.new("#{fixture_path}/movies/ios_rotate180.mov") }
 
         it "should have correct rotation detected" do
-          movie.rotation.should == 180
+          expect(movie.rotation).to eq(180)
         end
         it "should have untouched width and height" do
-          movie.width.should == 1920
-          movie.height.should == 1080
+          expect(movie.width).to eq(1920)
+          expect(movie.height).to eq(1080)
         end
       end
 
@@ -101,11 +101,11 @@ module FFMPEG
         let(:movie) { Movie.new("#{fixture_path}/movies/ios_rotate270.mov") }
 
         it "should have correct rotation detected" do
-          movie.rotation.should == 270
+          expect(movie.rotation).to eq(270)
         end
         it "should have switched width and height" do
-          movie.width.should == 1080
-          movie.height.should == 1920
+          expect(movie.width).to eq(1080)
+          expect(movie.height).to eq(1920)
         end
       end
 
@@ -113,11 +113,11 @@ module FFMPEG
         let(:movie) { Movie.new("#{fixture_path}/movies/broken.mp4") }
 
         it "should not be valid" do
-          movie.should_not be_valid
+          expect(movie).to_not be_valid
         end
 
         it "should have nil calculated_aspect_ratio" do
-          movie.calculated_aspect_ratio.should be_nil
+          expect(movie.calculated_aspect_ratio).to be_nil
         end
       end
 
@@ -125,17 +125,17 @@ module FFMPEG
         let(:movie) { Movie.new("#{fixture_path}/movies/weird_aspect.small.mpg") }
 
         it "should parse the DAR" do
-          movie.dar.should == "704:405"
+          expect(movie.dar).to eq("704:405")
         end
 
         it "should have correct calculated_aspect_ratio" do
-          movie.calculated_aspect_ratio.to_s[0..14].should == "1.7382716049382" # substringed to be 1.9 compatible
+          expect(movie.calculated_aspect_ratio.to_s[0..14]).to eq("1.7382716049382") # substringed to be 1.9 compatible
         end
       end
 
       describe 'Special cases: ' do
         let(:movie) do
-          Open3.stub(:popen3).and_yield(nil,fake_output,nil)
+          allow(Open3).to receive(:popen3).and_yield(nil,fake_output,nil)
           Movie.new(__FILE__)
         end
 
@@ -143,11 +143,11 @@ module FFMPEG
           let(:fixture_file) { 'file_with_weird_dar.txt' }
 
           it "should parse the DAR" do
-            movie.dar.should == "0:1"
+            expect(movie.dar).to eq("0:1")
           end
 
           it "should calculate using width and height instead" do
-            movie.calculated_aspect_ratio.to_s[0..14].should == "1.7777777777777" # substringed to be 1.9 compatible
+            expect(movie.calculated_aspect_ratio.to_s[0..14]).to eq("1.7777777777777") # substringed to be 1.9 compatible
           end
         end
 
@@ -155,11 +155,11 @@ module FFMPEG
           let(:fixture_file) { 'file_with_weird_sar.txt' }
 
           it 'should parse the SAR' do
-            movie.sar.should == '0:1'
+            expect(movie.sar).to eq('0:1')
           end
 
           it 'should using square SAR, 1.0 instead' do
-            movie.calculated_pixel_aspect_ratio.to_s[0..14].should == '1' # substringed to be 1.9 compatible
+            expect(movie.calculated_pixel_aspect_ratio.to_s[0..14]).to eq('1') # substringed to be 1.9 compatible
           end
         end
 
@@ -175,7 +175,7 @@ module FFMPEG
           let(:fixture_file) { 'file_with_surround_sound.txt' }
 
           it "should have 6 audio channels" do
-            movie.audio_channels.should == 6
+            expect(movie.audio_channels).to eq(6)
           end
         end
 
@@ -183,7 +183,7 @@ module FFMPEG
           let(:fixture_file) { 'file_with_no_audio.txt' }
 
           it "should have nil audio channels" do
-            movie.audio_channels.should == nil
+            expect(movie.audio_channels).to eq(nil)
           end
         end
 
@@ -191,12 +191,12 @@ module FFMPEG
           let(:fixture_file) { 'file_with_non_supported_audio_stdout.txt' }
           let(:movie) do
             fake_stderr = StringIO.new(File.read("#{fixture_path}/outputs/file_with_non_supported_audio_stderr.txt"))
-            Open3.stub(:popen3).and_yield(nil,fake_output,fake_stderr)
+            allow(Open3).to receive(:popen3).and_yield(nil,fake_output,fake_stderr)
             Movie.new(__FILE__)
           end
 
           it "should not be valid" do
-            movie.should_not be_valid
+            expect(movie).to_not be_valid
           end
         end
 
@@ -206,11 +206,11 @@ module FFMPEG
         let(:movie) { Movie.new("#{fixture_path}/movies/weird_aspect.small.mpg") }
 
         it "should parse the SAR" do
-          movie.sar.should == "64:45"
+          expect(movie.sar).to eq("64:45")
         end
 
         it "should have correct calculated_pixel_aspect_ratio" do
-          movie.calculated_pixel_aspect_ratio.to_s[0..14].should == "1.4222222222222" # substringed to be 1.9 compatible
+          expect(movie.calculated_pixel_aspect_ratio.to_s[0..14]).to eq("1.4222222222222") # substringed to be 1.9 compatible
         end
       end
 
@@ -218,7 +218,7 @@ module FFMPEG
         let(:movie) { Movie.new("#{fixture_path}/movies/awesome movie.mov") }
 
         it "should remember the movie path" do
-          movie.path.should == "#{fixture_path}/movies/awesome movie.mov"
+          expect(movie.path).to eq("#{fixture_path}/movies/awesome movie.mov")
         end
 
         it "should parse duration to number of seconds" do
@@ -226,40 +226,40 @@ module FFMPEG
         end
 
         it "should parse the bitrate" do
-          movie.bitrate.should == 481846
+          expect(movie.bitrate).to eq(481846)
         end
 
         it "should return nil rotation when no rotation exists" do
-          movie.rotation.should == nil
+          expect(movie.rotation).to eq(nil)
         end
 
         it "should parse the creation_time" do
-          movie.creation_time.should == Time.parse("2010-02-05 16:05:04")
+          expect(movie.creation_time).to eq(Time.parse("2010-02-05 16:05:04"))
         end
 
         it "should parse video stream information" do
-          movie.video_stream.should == "h264 (Main) (avc1 / 0x31637661), yuv420p, 640x480 [SAR 1:1 DAR 4:3]"
+          expect(movie.video_stream).to eq("h264 (Main) (avc1 / 0x31637661), yuv420p, 640x480 [SAR 1:1 DAR 4:3]")
         end
 
         it "should know the video codec" do
-          movie.video_codec.should =~ /h264/
+          expect(movie.video_codec).to match(/h264/)
         end
 
         it "should know the colorspace" do
-          movie.colorspace.should == "yuv420p"
+          expect(movie.colorspace).to eq("yuv420p")
         end
 
         it "should know the resolution" do
-          movie.resolution.should == "640x480"
+          expect(movie.resolution).to eq("640x480")
         end
 
         it "should know the video bitrate" do
-          movie.video_bitrate.should == 371185
+          expect(movie.video_bitrate).to eq(371185)
         end
 
         it "should know the width and height" do
-          movie.width.should == 640
-          movie.height.should == 480
+          expect(movie.width).to eq(640)
+          expect(movie.height).to eq(480)
         end
 
         it "should know the framerate" do
@@ -267,39 +267,39 @@ module FFMPEG
         end
 
         it "should parse audio stream information" do
-          movie.audio_stream.should == "aac (mp4a / 0x6134706d), 44100 Hz, stereo, fltp, 75832 bit/s"
+          expect(movie.audio_stream).to eq("aac (mp4a / 0x6134706d), 44100 Hz, stereo, fltp, 75832 bit/s")
         end
 
         it "should know the audio codec" do
-          movie.audio_codec.should =~ /aac/
+          expect(movie.audio_codec).to match(/aac/)
         end
 
         it "should know the sample rate" do
-          movie.audio_sample_rate.should == 44100
+          expect(movie.audio_sample_rate).to eq(44100)
         end
 
         it "should know the number of audio channels" do
-          movie.audio_channels.should == 2
+          expect(movie.audio_channels).to eq(2)
         end
 
         it "should know the audio bitrate" do
-          movie.audio_bitrate.should == 75832
+          expect(movie.audio_bitrate).to eq(75832)
         end
 
-        it "should should be valid" do
-          movie.should be_valid
+        it "should be valid" do
+          expect(movie).to be_valid
         end
 
         it "should calculate the aspect ratio" do
-          movie.calculated_aspect_ratio.to_s[0..14].should == "1.3333333333333" # substringed to be 1.9 compatible
+          expect(movie.calculated_aspect_ratio.to_s[0..14]).to eq("1.3333333333333") # substringed to be 1.9 compatible
         end
 
         it "should know the file size" do
-          movie.size.should == 455546
+          expect(movie.size).to eq(455546)
         end
 
         it "should know the container" do
-          movie.container.should == "mov,mp4,m4a,3gp,3g2,mj2"
+          expect(movie.container).to eq("mov,mp4,m4a,3gp,3g2,mj2")
         end
       end
     end
@@ -308,7 +308,7 @@ module FFMPEG
       let(:movie) { Movie.new("#{fixture_path}/movies/sideways movie.mov") }
 
       it "should parse the rotation" do
-        movie.rotation.should == 90
+        expect(movie.rotation).to eq(90)
       end
     end
 
@@ -318,10 +318,10 @@ module FFMPEG
       it "should run the transcoder" do
 
         transcoder_double = double(Transcoder)
-        Transcoder.should_receive(:new).
+        expect(Transcoder).to receive(:new).
           with(movie, "#{tmp_path}/awesome.flv", {custom: "-vcodec libx264"}, preserve_aspect_ratio: :width).
           and_return(transcoder_double)
-        transcoder_double.should_receive(:run)
+        expect(transcoder_double).to receive(:run)
 
         movie.transcode("#{tmp_path}/awesome.flv", {custom: "-vcodec libx264"}, preserve_aspect_ratio: :width)
       end
@@ -333,10 +333,10 @@ module FFMPEG
       it "should run the transcoder with screenshot option" do
 
         transcoder_double = double(Transcoder)
-        Transcoder.should_receive(:new).
+        expect(Transcoder).to receive(:new).
           with(movie, "#{tmp_path}/awesome.jpg", {seek_time: 2, dimensions: "640x480", screenshot: true}, preserve_aspect_ratio: :width).
           and_return(transcoder_double)
-        transcoder_double.should_receive(:run)
+        expect(transcoder_double).to receive(:run)
 
         movie.screenshot("#{tmp_path}/awesome.jpg", {seek_time: 2, dimensions: "640x480"}, preserve_aspect_ratio: :width)
       end

--- a/spec/ffmpeg/transcoder_spec.rb
+++ b/spec/ffmpeg/transcoder_spec.rb
@@ -27,7 +27,7 @@ module FFMPEG
     describe "transcoding" do
       context 'with default transcoder_options' do
         before do
-          FFMPEG.logger.should_receive(:info).at_least(:once)
+          expect(FFMPEG.logger).to receive(:info).at_least(:once)
         end
 
         context "when ffmpeg freezes" do
@@ -40,7 +40,7 @@ module FFMPEG
           end
 
           it "should fail when the timeout is exceeded" do
-            FFMPEG.logger.should_receive(:error)
+            expect(FFMPEG.logger).to receive(:error)
             transcoder = Transcoder.new(movie, "#{tmp_path}/timeout.mp4")
             expect { transcoder.run }.to raise_error(FFMPEG::Error, /Process hung/)
           end
@@ -59,7 +59,7 @@ module FFMPEG
 
           it 'should still work with (NTSC target)' do
             encoded = Transcoder.new(movie, "#{tmp_path}/awesome.mpg",  target: 'ntsc-vcd').run
-            encoded.resolution.should == '352x240'
+            expect(encoded.resolution).to eq('352x240')
           end
 
           after { Transcoder.timeout = @original_timeout }
@@ -71,10 +71,10 @@ module FFMPEG
           transcoder = Transcoder.new(movie, "#{tmp_path}/awesome.flv")
           progress_updates = []
           transcoder.run { |progress| progress_updates << progress }
-          transcoder.encoded.should be_valid
-          progress_updates.should include(0.0, 1.0)
-          progress_updates.length.should >= 3
-          File.exists?("#{tmp_path}/awesome.flv").should be_truthy
+          expect(transcoder.encoded).to be_valid
+          expect(progress_updates).to include(0.0, 1.0)
+          expect(progress_updates.length).to be >= 3
+          expect(File.exists?("#{tmp_path}/awesome.flv")).to be_truthy
         end
 
         it "should transcode the movie with EncodingOptions" do
@@ -84,14 +84,14 @@ module FFMPEG
                      audio_codec: "libmp3lame", audio_bitrate: 32, audio_sample_rate: 22050, audio_channels: 1}
 
           encoded = Transcoder.new(movie, "#{tmp_path}/optionalized.mp4", options).run
-          encoded.video_bitrate.should be_within(90000).of(300000)
-          encoded.video_codec.should =~ /h264/
-          encoded.resolution.should == "320x240"
-          encoded.frame_rate.should == 10.0
-          encoded.audio_bitrate.should be_within(2000).of(32000)
-          encoded.audio_codec.should =~ /mp3/
-          encoded.audio_sample_rate.should == 22050
-          encoded.audio_channels.should == 1
+          expect(encoded.video_bitrate).to be_within(90000).of(300000)
+          expect(encoded.video_codec).to match(/h264/)
+          expect(encoded.resolution).to eq("320x240")
+          expect(encoded.frame_rate).to eq(10.0)
+          expect(encoded.audio_bitrate).to be_within(2000).of(32000)
+          expect(encoded.audio_codec).to match(/mp3/)
+          expect(encoded.audio_sample_rate).to eq(22050)
+          expect(encoded.audio_channels).to eq(1)
         end
 
         context "with aspect ratio preservation" do
@@ -104,30 +104,30 @@ module FFMPEG
             special_options = {preserve_aspect_ratio: :width}
 
             encoded = Transcoder.new(@movie, "#{tmp_path}/preserved_aspect.mp4", @options, special_options).run
-            encoded.resolution.should == "320x180"
+            expect(encoded.resolution).to eq("320x180")
           end
 
           it "should work on height" do
             special_options = {preserve_aspect_ratio: :height}
 
             encoded = Transcoder.new(@movie, "#{tmp_path}/preserved_aspect.mp4", @options, special_options).run
-            encoded.resolution.should == "426x240"
+            expect(encoded.resolution).to eq("426x240")
           end
 
           it "should not be used if original resolution is undeterminable" do
-            @movie.should_receive(:calculated_aspect_ratio).and_return(nil)
+            expect(@movie).to receive(:calculated_aspect_ratio).and_return(nil)
             special_options = {preserve_aspect_ratio: :height}
 
             encoded = Transcoder.new(@movie, "#{tmp_path}/preserved_aspect.mp4", @options, special_options).run
-            encoded.resolution.should == "320x240"
+            expect(encoded.resolution).to eq("320x240")
           end
 
           it "should round to resolutions divisible by 2" do
-            @movie.should_receive(:calculated_aspect_ratio).at_least(:once).and_return(1.234)
+            expect(@movie).to receive(:calculated_aspect_ratio).at_least(:once).and_return(1.234)
             special_options = {preserve_aspect_ratio: :width}
 
             encoded = Transcoder.new(@movie, "#{tmp_path}/preserved_aspect.mp4", @options, special_options).run
-            encoded.resolution.should == "320x260" # 320 / 1.234 should at first be rounded to 259
+            expect(encoded.resolution).to eq("320x260") # 320 / 1.234 should at first be rounded to 259
           end
         end
 
@@ -135,8 +135,8 @@ module FFMPEG
           FileUtils.rm_f "#{tmp_path}/string_optionalized.flv"
 
           encoded = Transcoder.new(movie, "#{tmp_path}/string_optionalized.flv", "-s 300x200 -ac 2").run
-          encoded.resolution.should == "300x200"
-          encoded.audio_channels.should == 2
+          expect(encoded.resolution).to eq("300x200")
+          expect(encoded.audio_channels).to eq(2)
         end
 
         it "should transcode the movie which name include single quotation mark" do
@@ -160,7 +160,7 @@ module FFMPEG
         end
 
         it "should fail when given an invalid movie" do
-          FFMPEG.logger.should_receive(:error)
+          expect(FFMPEG.logger).to receive(:error)
           movie = Movie.new(__FILE__)
           transcoder = Transcoder.new(movie, "#{tmp_path}/fail.flv")
           expect { transcoder.run }.to raise_error(FFMPEG::Error, /no output file created/)
@@ -169,24 +169,24 @@ module FFMPEG
         it "should encode to the specified duration if given" do
           encoded = Transcoder.new(movie, "#{tmp_path}/durationalized.mp4", duration: 2).run
 
-          encoded.duration.should >= 1.8
-          encoded.duration.should <= 2.2
+          expect(encoded.duration).to be >= 1.8
+          expect(encoded.duration).to be <= 2.2
         end
 
         context "with screenshot option" do
           it "should transcode to original movies resolution by default" do
             encoded = Transcoder.new(movie, "#{tmp_path}/image.jpg", screenshot: true).run
-            encoded.resolution.should == "640x480"
+            expect(encoded.resolution).to eq("640x480")
           end
 
           it "should transcode absolute resolution if specified" do
             encoded = Transcoder.new(movie, "#{tmp_path}/image.bmp", screenshot: true, seek_time: 3, resolution: '400x200').run
-            encoded.resolution.should == "400x200"
+            expect(encoded.resolution).to eq("400x200")
           end
 
           it "should be able to preserve aspect ratio" do
             encoded = Transcoder.new(movie, "#{tmp_path}/image.png", {screenshot: true, seek_time: 4, resolution: '320x500'}, preserve_aspect_ratio: :width).run
-            encoded.resolution.should == "320x240"
+            expect(encoded.resolution).to eq("320x240")
           end
         end
 
@@ -215,19 +215,19 @@ module FFMPEG
     context "with :validate => false set as transcoding_options" do
       let(:transcoder) { Transcoder.new(movie, "tmp.mp4", {},{:validate => false}) }
 
-      before { transcoder.stub(:transcode_movie) }
+      before { allow(transcoder).to receive(:transcode_movie) }
       after { FileUtils.rm_f "#{tmp_path}/tmp.mp4" }
 
       it "should not validate the movie output" do
-        transcoder.should_not_receive(:validate_output_file)
-        transcoder.stub(:encoded)
+        expect(transcoder).to_not receive(:validate_output_file)
+        allow(transcoder).to receive(:encoded)
         transcoder.run
       end
 
       it "should not return Movie object" do
-        transcoder.stub(:validate_output_file)
-        transcoder.should_not_receive(:encoded)
-        transcoder.run.should == nil
+        allow(transcoder).to receive(:validate_output_file)
+        expect(transcoder).to_not receive(:encoded)
+        expect(transcoder.run).to eq(nil)
       end
     end
   end

--- a/spec/streamio-ffmpeg_spec.rb
+++ b/spec/streamio-ffmpeg_spec.rb
@@ -7,18 +7,18 @@ describe FFMPEG do
     end
     
     it "should be a Logger" do
-      FFMPEG.logger.should be_instance_of(Logger)
+      expect(FFMPEG.logger).to be_instance_of(Logger)
     end
     
     it "should be at info level" do
       FFMPEG.logger = nil # Reset the logger so that we get the default
-      FFMPEG.logger.level.should == Logger::INFO
+      expect(FFMPEG.logger.level).to eq(Logger::INFO)
     end
     
     it "should be assignable" do
       new_logger = Logger.new(STDOUT)
       FFMPEG.logger = new_logger
-      FFMPEG.logger.should == new_logger
+      expect(FFMPEG.logger).to eq(new_logger)
     end
   end
 

--- a/streamio-ffmpeg.gemspec
+++ b/streamio-ffmpeg.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('multi_json', '~> 1.8')
 
-  s.add_development_dependency("rspec", "~> 2.14")
+  s.add_development_dependency("rspec", "~> 3")
   s.add_development_dependency("rake", "~> 10.1")
 
   s.files        = Dir.glob("lib/**/*") + %w(README.md LICENSE CHANGELOG)


### PR DESCRIPTION
Some of the tests were half-using the new syntax already so I rewrote all of the tests to take advantage of latest rspec.