### PR TITLE
Raise error if JSON parsing fails.

### DIFF
--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -25,7 +25,11 @@ module FFMPEG
 
       fix_encoding(std_output)
 
-      metadata = MultiJson.load(std_output, symbolize_keys: true)
+      begin
+        metadata = MultiJson.load(std_output, symbolize_keys: true)
+      rescue MultiJson::ParseError
+        raise "Could not parse output from FFProbe:\n#{ std_output }"
+      end
 
       if metadata.key?(:error)
 

--- a/spec/ffmpeg/movie_spec.rb
+++ b/spec/ffmpeg/movie_spec.rb
@@ -139,6 +139,14 @@ module FFMPEG
           Movie.new(__FILE__)
         end
 
+        context "given a file with bad JSON" do
+          let(:fixture_file) { 'file_with_bad_json.txt' }
+
+          it 'should raise an exception' do
+            expect { movie }.to raise_error RuntimeError, /Could not parse output from FFProbe/
+          end
+        end
+
         context "given an impossible DAR" do
           let(:fixture_file) { 'file_with_weird_dar.txt' }
 

--- a/spec/fixtures/outputs/file_with_bad_json.txt
+++ b/spec/fixtures/outputs/file_with_bad_json.txt
@@ -1,0 +1,4 @@
+dyld: Library not loaded: /usr/local/opt/openh264/lib/libopenh264.1.dylib
+  Referenced from: /usr/local/bin/ffprobe
+  Reason: image not found
+[1]    46696 abort      /usr/local/bin/ffprobe -i spec/fixtures/village.mov -print_format json


### PR DESCRIPTION
Raises a slightly more useful error message if `MultiJson.load` chokes on the output from `ffprobe`, as might happen when, for example, the binary is built incorrectly.