### PR TITLE
Adds support for redirected URLs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: ruby
 rvm:
- - 1.9.3
+ - 2.3.1
 cache:
-  - bundler
+ - bundler
 before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get install -y ffmpeg
+ - gem update bundler
+ - gem update
+ - sudo apt-get -qq update
+ - sudo apt-get -y install autoconf automake build-essential libass-dev libfreetype6-dev libtheora-dev libtool libvorbis-dev pkg-config texinfo zlib1g-dev libx264-dev libmp3lame-dev
+ - sudo apt-get install -y ffmpeg

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: ruby
+rvm:
+ - 1.9.3
+cache:
+  - bundler
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y ffmpeg

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 == Master
 
-Current with 3.0.0
+Current with 3.0.1
+
+== 3.0.1 2016-11-10
+
+Improvements:
+* Issue #144 is fixed. Of a nil movie is presented to transcode, the progress block does not fail
+* Issue #145 Adds ability to follow URLs when presented as Movie inputs
+
 
 == 3.0.0 2016-09-07
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source "https://rubygems.org"
 
 gemspec
+
+group :test do
+  gem 'webmock'
+end

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ movie.transcode("movie.mp4") { |progress| puts progress } # 0.2 ... 0.5 ... 1.0
 Give custom command line options with an array.
 
 ``` ruby
-movie.transcode("movie.mp4", %w(-ac aac -vc libx264 -ac 2 ...)")
+movie.transcode("movie.mp4", %w(-ac aac -vc libx264 -ac 2 ...))
 ```
 
 Use the EncodingOptions parser for humanly readable transcoding options. Below you'll find most of the supported options.

--- a/lib/ffmpeg/errors.rb
+++ b/lib/ffmpeg/errors.rb
@@ -1,4 +1,6 @@
 module FFMPEG
   class Error < StandardError
   end
+  class HTTPTooManyRequests < StandardError
+  end
 end

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -81,8 +81,11 @@ module FFMPEG
               else # better make sure it wont blow up in case of unexpected output
                 time = 0.0
               end
-              progress = time / @movie.duration
-              yield(progress) if block_given?
+
+              if @movie
+                progress = time / @movie.duration
+                yield(progress) if block_given?
+              end
             end
           end
 

--- a/lib/ffmpeg/version.rb
+++ b/lib/ffmpeg/version.rb
@@ -1,3 +1,3 @@
 module FFMPEG
-  VERSION = '3.0.0'
+  VERSION = '3.0.1'
 end

--- a/lib/streamio-ffmpeg.rb
+++ b/lib/streamio-ffmpeg.rb
@@ -72,6 +72,24 @@ module FFMPEG
     @ffprobe_binary = bin
   end
 
+  # Get the maximum number of http redirect attempts
+  #
+  # @return [Integer] the maximum number of retries
+  def self.max_http_redirect_attempts
+    @max_http_redirect_attempts.nil? ? 10 : @max_http_redirect_attempts
+  end
+
+  # Set the maximum number of http redirect attempts.
+  #
+  # @param [Integer] the maximum number of retries
+  # @return [Integer] the number of retries you set
+  # @raise Errno::ENOENT if the value is negative or not an Integer
+  def self.max_http_redirect_attempts=(v)
+    raise Errno::ENOENT, 'max_http_redirect_attempts must be an integer' if v && !v.is_a?(Integer)
+    raise Errno::ENOENT, 'max_http_redirect_attempts may not be negative' if v && v < 0
+    @max_http_redirect_attempts = v
+  end
+
   # Cross-platform way of finding an executable in the $PATH.
   #
   #   which('ruby') #=> /usr/bin/ruby

--- a/spec/ffmpeg/movie_spec.rb
+++ b/spec/ffmpeg/movie_spec.rb
@@ -28,10 +28,10 @@ module FFMPEG
         end
       end
 
-      context "given an URL" do
+      context "given a URL" do
+        before(:context) { start_web_server }
+        after(:context) { stop_web_server }
         context "that is correct" do
-          before(:context) { start_web_server }
-          after(:context) { stop_web_server }
 
           let(:movie) { Movie.new("http://127.0.0.1:8000/awesome%20movie.mov") }
 
@@ -50,12 +50,52 @@ module FFMPEG
           it "should be marked as remote" do
             expect(movie.remote?).to be_truthy
           end
-        end
-        context "that is incorrect" do
-          it "should raise an exception" do
-            expect { Movie.new("http://127.0.0.1:8000/awesome%20movie.mov") }.to raise_error(Errno::ENOENT)
+
+          context 'with a query string' do
+            # We're mocking this to fail on the same URL with the query string added.
+            # This means that we're passing the query string through using .request_uri
+            # rather than .path
+
+            it 'should not be found' do
+              expect { Movie.new('http://127.0.0.1:8000/awesome%20movie.mov?fail=1') }.to raise_error(Errno::ENOENT)
+            end
           end
-        end          
+        end
+        context "that does not exist" do
+          it "should raise an exception" do
+            expect { Movie.new("http://127.0.0.1:8000/awesome%20movie_missing.mov") }.to raise_error(Errno::ENOENT)
+          end
+        end
+        context 'that redirects' do
+          context 'to a remote uri' do
+            let(:movie) { Movie.new('http://www.redirect-example.com/moved_movie.mov') }
+
+            it "should know the file size" do
+              expect(movie.size).to eq(455_546)
+            end
+          end
+          context 'to a relative uri' do
+            let(:movie) { Movie.new('http://127.0.0.1:8000/deep_path/awesome%20movie.mov') }
+
+            it 'should know the file size' do
+              expect(movie.size).to eq(455_546)
+            end
+          end
+          context 'to a relative uri respecting redirect limits' do
+            before { FFMPEG.max_http_redirect_attempts = 0 }
+            after { FFMPEG.max_http_redirect_attempts = nil }
+
+            it 'raise FFMPEG::HTTPTooManyRequests' do
+              expect { Movie.new('http://127.0.0.1:8000/deep_path/awesome%20movie.mov') }.to raise_error(FFMPEG::HTTPTooManyRequests)
+            end
+          end
+
+          context 'to a relative uri with too many redirects' do
+            it 'should know the file size' do
+              expect { Movie.new('http://www.toomany-redirects-example.com/moved_movie.mov') }.to raise_error(FFMPEG::HTTPTooManyRequests)
+            end
+          end
+        end
       end
 
       context "given a non movie file" do

--- a/spec/ffmpeg/transcoder_spec.rb
+++ b/spec/ffmpeg/transcoder_spec.rb
@@ -370,6 +370,15 @@ module FFMPEG
               expect { transcoder.run }.to raise_error(FFMPEG::Error, /encoded file is invalid/)
             end
           end
+
+          context 'with no movie defined' do
+            let(:movie) { nil }
+
+            it 'should not raise an error' do
+              expect { transcoder.run }.to_not raise_error
+            end
+          end
+
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,12 +2,36 @@ require 'bundler'
 Bundler.require
 
 require 'fileutils'
+require 'webmock/rspec'
+WebMock.allow_net_connect!
 
 FFMPEG.logger = Logger.new(nil)
 
 RSpec.configure do |config|
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
+
+  config.before(:each) do
+    stub_request(:head, /redirect-example.com/).
+        with(:headers => {'Accept'=>'*/*', 'User-Agent' => 'Ruby'}).
+        to_return(status: 302, headers: {
+            location: 'http://127.0.0.1:8000/awesome%20movie.mov'
+        })
+    stub_request(:head, 'http://127.0.0.1:8000/deep_path/awesome%20movie.mov').
+        with(:headers => {'Accept'=>'*/*', 'User-Agent' => 'Ruby'}).
+        to_return(status: 302, headers: {
+            location: '/awesome%20movie.mov'
+        })
+    stub_request(:head, 'http://127.0.0.1:8000/awesome%20movie.mov?fail=1').
+        with(:headers => {'Accept'=>'*/*', 'User-Agent' => 'Ruby'}).
+        to_return(status: 404, headers: { })
+    stub_request(:head, /toomany-redirects-example/).
+        with(:headers => {'Accept'=>'*/*', 'User-Agent' => 'Ruby'}).
+        to_return(status: 302, headers: {
+            location: '/awesome%20movie.mov'
+        })
+
+  end
 end
 
 def fixture_path

--- a/spec/streamio-ffmpeg_spec.rb
+++ b/spec/streamio-ffmpeg_spec.rb
@@ -77,4 +77,27 @@ describe FFMPEG do
     end
 
   end
+
+  describe '.max_http_redirect_attempts' do
+    after(:each) do
+      FFMPEG.max_http_redirect_attempts = nil
+    end
+
+    it 'should default to 10' do
+      expect(FFMPEG.max_http_redirect_attempts).to eq 10
+    end
+
+    it 'should be an Integer' do
+      expect { FFMPEG.max_http_redirect_attempts = 1.23 }.to raise_error(Errno::ENOENT)
+    end
+
+    it 'should not be negative' do
+      expect { FFMPEG.max_http_redirect_attempts = -1 }.to raise_error(Errno::ENOENT)
+    end
+
+    it 'should be assignable' do
+      FFMPEG.max_http_redirect_attempts = 5
+      expect(FFMPEG.max_http_redirect_attempts).to eq 5
+    end
+  end
 end


### PR DESCRIPTION
This pull request adds support for redirected URLs. It enables the maximum redirect retries to be set and adds specs to test the new features.

The default retry attempts is 10. To change, use `FFMPEG.max_http_redirect_attempts`.
