### PR TITLE
Video generation fails when creating a video from images and @movie is nil

### DIFF
--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -81,7 +81,10 @@ module FFMPEG
               else # better make sure it wont blow up in case of unexpected output
                 time = 0.0
               end
-              progress = time / @movie.duration
+              progress = -1
+              if !@movie.nil?
+                progress = time / @movie.duration
+              end
               yield(progress) if block_given?
             end
           end


### PR DESCRIPTION
Hello, I was having problems when trying to generate a video from screenshots.
I found out that the trasceiver.rb file is assuming a @movie exists, even when it doesn't.
I just added a check for that scenario, and a fallback value for it.
Then it works.

Could you take a look? I wasn't sure about what progress number to fallback. I set -1 because to me it basically means, "invalid to determine" since we don't have a video to check for and properly return a progress value.

Thanks
Nice plugin BTW
