### PR TITLE
Allow for Windows filepaths

### DIFF
--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -132,7 +132,7 @@ module FFMPEG
     end
 
     def remote?
-      @path =~ URI::regexp
+      @path =~ URI::regexp(%w(http https))
     end
 
     def local?


### PR DESCRIPTION
If you use a Windows filepath, for example by doing:

`irb(main):004:0> movie = FFMPEG::Movie.new("C:\\Ruby23-x64\\streamio-ffmpeg\\spec\\fixtures\\movies\\awesome'movie.mov")`

this gets accepted by the original regex as a URI and leads to problems in the head method when it attempts to use the path as such:

`NameError: uninitialized constant FFMPEG::Movie::SocketError`

A slight amend to the regex fixes this for Windows users (tested on Windows 7 and Windows 10, with Ruby 2.3) without appearing to affect URIs or non-Windows paths. It reduces movie_spec failures from 65 examples to 1 example (only because the example is for a video file with a question mark in it and Windows doesn't allow files with a question mark anyway).

Many thanks for this gem!