### PR TITLE
Specs for slideshows without a movie, closes #144

### DIFF
--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -81,8 +81,11 @@ module FFMPEG
               else # better make sure it wont blow up in case of unexpected output
                 time = 0.0
               end
-              progress = time / @movie.duration
-              yield(progress) if block_given?
+
+              if @movie
+                progress = time / @movie.duration
+                yield(progress) if block_given?
+              end
             end
           end
 

--- a/spec/ffmpeg/transcoder_spec.rb
+++ b/spec/ffmpeg/transcoder_spec.rb
@@ -370,6 +370,15 @@ module FFMPEG
               expect { transcoder.run }.to raise_error(FFMPEG::Error, /encoded file is invalid/)
             end
           end
+
+          context 'with no movie defined' do
+            let(:movie) { nil }
+
+            it 'should not raise an error' do
+              expect { transcoder.run }.to_not raise_error
+            end
+          end
+
         end
       end
     end


### PR DESCRIPTION
When creating a slideshow, a movie isn't required. #144 attempted to address this. This pull request will supersede it.
