### PR TITLE
Make progress calculation robust when @movie isn't defined.

### DIFF
--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -81,7 +81,7 @@ module FFMPEG
               else # better make sure it wont blow up in case of unexpected output
                 time = 0.0
               end
-              progress = time / @movie.duration
+              progress = time / (@movie ? @movie.duration : 1.0)
               yield(progress) if block_given?
             end
           end


### PR DESCRIPTION
If using Transcoder directly, @movie is nil.  This breaks the progress calculation.    Put in a check around @movie 
