### PR TITLE
Do not trust `unset value` in dar/sar, in flipped movie

### DIFF
--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -195,15 +195,15 @@ module FFMPEG
     def aspect_from_dar
       return nil unless dar
       w, h = dar.split(":")
-      aspect = (@rotation==nil) || (@rotation==180)? (w.to_f / h.to_f):(h.to_f / w.to_f)
-      aspect.zero? ? nil : aspect
+      return nil if w == '0' || h == '0'
+      @rotation.nil? || (@rotation == 180) ? (w.to_f / h.to_f) : (h.to_f / w.to_f)
     end
 
     def aspect_from_sar
       return nil unless sar
       w, h = sar.split(":")
-      aspect = (@rotation==nil) || (@rotation==180)? (w.to_f / h.to_f):(h.to_f / w.to_f)
-      aspect.zero? ? nil : aspect
+      return nil if w == '0' || h == '0'
+      @rotation.nil? || (@rotation == 180) ? (w.to_f / h.to_f) : (h.to_f / w.to_f)
     end
 
     def aspect_from_dimensions

--- a/spec/ffmpeg/movie_spec.rb
+++ b/spec/ffmpeg/movie_spec.rb
@@ -245,11 +245,18 @@ module FFMPEG
           let(:fixture_file) { 'file_with_weird_dar.txt' }
 
           it "should parse the DAR" do
-            expect(movie.dar).to eq("0:1")
+            expect(movie.dar).to eq('0:1')
           end
 
           it "should calculate using width and height instead" do
             expect(movie.calculated_aspect_ratio.to_s[0..14]).to eq("1.7777777777777") # substringed to be 1.9 compatible
+          end
+
+          context 'when width/height is flipped' do
+            before { movie.instance_variable_set :@rotation, 90 }
+            it "should calculate using width and height instead" do
+              expect(movie.calculated_aspect_ratio).to eq(0.5625)
+            end
           end
         end
 
@@ -262,6 +269,13 @@ module FFMPEG
 
           it 'should using square SAR, 1.0 instead' do
             expect(movie.calculated_pixel_aspect_ratio.to_s[0..14]).to eq('1') # substringed to be 1.9 compatible
+          end
+
+          context 'when width/height is flipped' do
+            before { movie.instance_variable_set :@rotation, 90 }
+            it 'should using square SAR, 1.0 instead' do
+              expect(movie.calculated_pixel_aspect_ratio).to eq(1)
+            end
           end
         end
 


### PR DESCRIPTION
According to https://trac.ffmpeg.org/ticket/3798
ffprobe `might` return `0:1` as dar/sar, which they mean `invalid/unset`
Make sure we dont trust that value, even on the rotated movie.

closes #150

---

Couldn't find the exact spec of `what ffprobe returns as display_aspect_ratio/sample_aspect_ratio`,
but it surely returns `0:1` when I create a video with my iPhone.

Maybe we should ignore exact **0:1** only (here I am trying to stop calculationg on `0:ANY or ANY:0`)
comment welcomed.
