### PR TITLE
Expose multiple audio streams.

### DIFF
--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -6,7 +6,7 @@ module FFMPEG
   class Movie
     attr_reader :path, :duration, :time, :bitrate, :rotation, :creation_time
     attr_reader :video_stream, :video_codec, :video_bitrate, :colorspace, :width, :height, :sar, :dar, :frame_rate
-    attr_reader :audio_stream, :audio_codec, :audio_bitrate, :audio_sample_rate, :audio_channels
+    attr_reader :audio_streams, :audio_stream, :audio_codec, :audio_bitrate, :audio_sample_rate, :audio_channels, :audio_tags
     attr_reader :container
     attr_reader :metadata, :format_tags
 
@@ -97,15 +97,28 @@ module FFMPEG
                       end
         end
 
-        # TODO: Handle multiple audio codecs
-        audio_stream = audio_streams.first
+        @audio_streams = audio_streams.map do |stream|
+          {
+            :index => stream[:index],
+            :channels => stream[:channels].to_i,
+            :codec_name => stream[:codec_name],
+            :sample_rate => stream[:sample_rate].to_i,
+            :bitrate => stream[:bit_rate].to_i,
+            :channel_layout => stream[:channel_layout],
+            :tags => stream[:streams],
+            :overview => "#{stream[:codec_name]} (#{stream[:codec_tag_string]} / #{stream[:codec_tag]}), #{stream[:sample_rate]} Hz, #{stream[:channel_layout]}, #{stream[:sample_fmt]}, #{stream[:bit_rate]} bit/s"
+          }
+        end
+
+        audio_stream = @audio_streams.first
         unless audio_stream.nil?
-          @audio_channels = audio_stream[:channels].to_i
+          @audio_channels = audio_stream[:channels]
           @audio_codec = audio_stream[:codec_name]
-          @audio_sample_rate = audio_stream[:sample_rate].to_i
-          @audio_bitrate = audio_stream[:bit_rate].to_i
+          @audio_sample_rate = audio_stream[:sample_rate]
+          @audio_bitrate = audio_stream[:bitrate]
           @audio_channel_layout = audio_stream[:channel_layout]
-          @audio_stream = "#{audio_codec} (#{audio_stream[:codec_tag_string]} / #{audio_stream[:codec_tag]}), #{audio_sample_rate} Hz, #{audio_channel_layout}, #{audio_stream[:sample_fmt]}, #{audio_bitrate} bit/s"
+          @audio_tags = audio_stream[:audio_tags]
+          @audio_stream = audio_stream[:overview]
         end
 
       end

--- a/spec/ffmpeg/movie_spec.rb
+++ b/spec/ffmpeg/movie_spec.rb
@@ -437,6 +437,30 @@ module FFMPEG
           expect(movie.container).to eq("mov,mp4,m4a,3gp,3g2,mj2")
         end
       end
+
+      context "given a movie file with 2 audio streams" do
+        let(:movie) { Movie.new("#{fixture_path}/movies/multi_audio_movie.mp4") }
+
+        it "should identify both audio streams" do
+          movie.audio_streams.length.should == 2
+        end
+
+        it "should assign audio properties to the properties of the first stream" do
+          audio_channels = movie.audio_streams[0][:channels]
+          audio_codec = movie.audio_streams[0][:codec_name]
+          audio_bitrate = movie.audio_streams[0][:bitrate]
+          audio_channel_layout = movie.audio_streams[0][:channel_layout]
+          audio_tags = movie.audio_streams[0][:tags]
+          stream_overview = movie.audio_streams[0][:overview]
+
+          movie.audio_channels.should == audio_channels
+          movie.audio_codec.should == audio_codec
+          movie.audio_bitrate.should == audio_bitrate
+          movie.audio_channel_layout.should == audio_channel_layout
+          movie.audio_tags.should == audio_tags
+          movie.audio_stream.should == stream_overview
+        end
+      end
     end
 
     context "given a rotated movie file" do


### PR DESCRIPTION
I'd like to make all available audio streams accessible through the `movie` object returned.
I've kept the the previous `audio_stream` attributes in tact for the purposes of backwards compatibility but, if you choose to go with this change and would like me to, I can add in a deprecation warning when accessing those attributes.

- [x] Expose all audio streams
- [x] Add tests specific for multiple audio tracks