### PR TITLE
Load net/http

### DIFF
--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -1,6 +1,7 @@
 require 'time'
 require 'multi_json'
 require 'uri'
+require 'net/http'
 
 module FFMPEG
   class Movie


### PR DESCRIPTION
This patch makes `net/http` available to the Movie class when reading a remote video.