### PR TITLE
Fix short lambda syntax error for compatibility with Ruby 1.9

### DIFF
--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -125,7 +125,7 @@ module FFMPEG
       end
 
       unsupported_stream_ids = unsupported_streams(std_error)
-      nil_or_unsupported = -> (stream) { stream.nil? || unsupported_stream_ids.include?(stream[:index]) }
+      nil_or_unsupported = ->(stream) { stream.nil? || unsupported_stream_ids.include?(stream[:index]) }
 
       @invalid = true if nil_or_unsupported.(video_stream) && nil_or_unsupported.(audio_stream)
       @invalid = true if @metadata.key?(:error)


### PR DESCRIPTION
Ruby 1.9 does not allow a space in the short lambda arrow operator:

twice = -> (x) { 2 * x }

causes a syntax error. Without a space:

twice = ->(x) { 2 * x }

Is compatible with 1.9 and 2.0

This fixes one instance of a short lambda declaration in movie.rb that causes a syntax error in ruby 1.9