### PR TITLE
Adds -profile:v and -pix_fmt flag options to encoding_options.rb

### DIFF
--- a/lib/ffmpeg/encoding_options.rb
+++ b/lib/ffmpeg/encoding_options.rb
@@ -172,10 +172,10 @@ module FFMPEG
       ["-i", value]
     end
 
-    def profile(value)
+    def convert_profile(value)
       ["-profile:v", value]
     end
-    
+
     def convert_watermark_filter(value)
       position = value[:position]
       padding_x = value[:padding_x] || 10

--- a/lib/ffmpeg/encoding_options.rb
+++ b/lib/ffmpeg/encoding_options.rb
@@ -176,9 +176,9 @@ module FFMPEG
       ["-profile:v", value]
     end
 
-#    def convert_pix_fmt(value)
-#      ["-pix_fmt", value]
-#    end
+    def convert_pix_fmt(value)
+      ["-pix_fmt", value]
+    end
 
     def convert_watermark_filter(value)
       position = value[:position]

--- a/lib/ffmpeg/encoding_options.rb
+++ b/lib/ffmpeg/encoding_options.rb
@@ -176,6 +176,10 @@ module FFMPEG
       ["-profile:v", value]
     end
 
+#    def convert_pix_fmt(value)
+#      ["-pix_fmt", value]
+#    end
+
     def convert_watermark_filter(value)
       position = value[:position]
       padding_x = value[:padding_x] || 10

--- a/lib/ffmpeg/encoding_options.rb
+++ b/lib/ffmpeg/encoding_options.rb
@@ -172,6 +172,10 @@ module FFMPEG
       ["-i", value]
     end
 
+    def profile(value)
+      ["-profile:v", value]
+    end
+    
     def convert_watermark_filter(value)
       position = value[:position]
       padding_x = value[:padding_x] || 10

--- a/spec/ffmpeg/encoding_options_spec.rb
+++ b/spec/ffmpeg/encoding_options_spec.rb
@@ -124,6 +124,14 @@ module FFMPEG
         expect(EncodingOptions.new(screenshot: true, vframes: 123, quality: 3).to_a).to eq(%w(-f image2 -vframes 123 -q:v 3))
       end
 
+      it "should accept and set profile:v" do
+        expect(EncodingOptions.new(profile: "baseline").to_a).to eq(%w(-profile:v baseline))
+      end
+
+      it "should accept and set pix_fmt" do
+        expect(EncodingOptions.new(pix_fmt: "yuv420p").to_a).to eq(%w(-pix_fmt yuv420p))
+      end
+
       it 'should put the parameters in order of codecs, presets, others' do
         opts = Hash.new
         opts[:frame_rate] = 25


### PR DESCRIPTION
Adds following options to encoding_options:

-pix_fmt ~ Allows specification of pixel format

-profile:v ~ Alternate syntax for specifying x264 base profile. I see there is an option for setting a -vprofile flag with convert_x264_vprofile, but that doesn't seem to work with my version of ffmpeg on osx (3.2.2).

Also includes passing specs.