### PR TITLE
Adds LKFS attribute and allows loudness normalization in transcoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ options = {
 movie.transcode("movie.mp4", options)
 ```
 
+Normalize the LKFS to -24:
+
+``` ruby
+options = { loudness_normalization: movie.normalize_command }
+
+movie.transcode("movie.mp4", options)
+```
+
 The transcode function returns a Movie object for the encoded file.
 
 ``` ruby

--- a/lib/ffmpeg/encoding_options.rb
+++ b/lib/ffmpeg/encoding_options.rb
@@ -141,6 +141,10 @@ module FFMPEG
       ["-ss", value]
     end
 
+    def convert_loudness_normalization(value)
+      ["-af", value]
+    end
+
     def convert_screenshot(value)
       result = []
       unless self[:vframes]

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -2,12 +2,13 @@ require 'time'
 require 'multi_json'
 require 'uri'
 require 'net/http'
+require 'json'
 
 module FFMPEG
   class Movie
     attr_reader :path, :duration, :time, :bitrate, :rotation, :creation_time
     attr_reader :video_stream, :video_codec, :video_bitrate, :colorspace, :width, :height, :sar, :dar, :level, :profile, :frame_rate
-    attr_reader :audio_streams, :audio_stream, :audio_codec, :audio_bitrate, :audio_sample_rate, :audio_channels, :audio_tags, :max_volume, :mean_volume
+    attr_reader :audio_streams, :audio_stream, :audio_codec, :audio_bitrate, :audio_sample_rate, :audio_channels, :audio_tags, :max_volume, :mean_volume, :lkfs
     attr_reader :container
     attr_reader :metadata, :format_tags
 
@@ -26,6 +27,8 @@ module FFMPEG
       end
 
       @path = path
+
+      set_lkfs
 
       # ffmpeg will output to stderr
       command = [FFMPEG.ffprobe_binary, '-i', path, *%w(-print_format json -show_format -show_streams -show_error)]
@@ -143,6 +146,23 @@ module FFMPEG
       @invalid = true if nil_or_unsupported.(video_stream) && nil_or_unsupported.(audio_stream)
       @invalid = true if @metadata.key?(:error)
       @invalid = true if std_error.include?("could not find codec parameters")
+    end
+
+    def set_lkfs
+      lkfs_command = [FFMPEG.ffmpeg_binary, '-i', path, '-af', *%w(loudnorm=I=-24:TP=-1.5:LRA=11:print_format=json -f null -)]
+      _stdin, _stdout, std_err, wait_thr = Open3.popen3(*lkfs_command)
+
+      if wait_thr.value.success?
+        stats = JSON.parse(std_err.read.lines[-12, 12].join)
+        @lkfs = stats['input_i'].to_f
+      else
+        raise "Could not retrieve lkfs"
+      end
+      std_err.flush
+    end
+
+    def set_mean_and_max_volume
+
     end
 
     def unsupported_streams(std_error)

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -8,7 +8,8 @@ module FFMPEG
   class Movie
     attr_reader :path, :duration, :time, :bitrate, :rotation, :creation_time
     attr_reader :video_stream, :video_codec, :video_bitrate, :colorspace, :width, :height, :sar, :dar, :level, :profile, :frame_rate
-    attr_reader :audio_streams, :audio_stream, :audio_codec, :audio_bitrate, :audio_sample_rate, :audio_channels, :audio_tags, :max_volume, :mean_volume, :lkfs
+    attr_reader :audio_streams, :audio_stream, :audio_codec, :audio_bitrate, :audio_sample_rate, :audio_channels, :audio_tags
+    attr_reader :max_volume, :mean_volume, :lkfs, :loudness_lra, :loudness_true_peak, :loudness_threshold, :target_offset, :normalize_command
     attr_reader :container
     attr_reader :metadata, :format_tags
 
@@ -28,7 +29,7 @@ module FFMPEG
 
       @path = path
 
-      set_lkfs
+      set_loudness
 
       # ffmpeg will output to stderr
       command = [FFMPEG.ffprobe_binary, '-i', path, *%w(-print_format json -show_format -show_streams -show_error)]
@@ -148,21 +149,26 @@ module FFMPEG
       @invalid = true if std_error.include?("could not find codec parameters")
     end
 
-    def set_lkfs
+    def set_loudness
       lkfs_command = [FFMPEG.ffmpeg_binary, '-i', path, '-af', *%w(loudnorm=I=-24:TP=-1.5:LRA=11:print_format=json -f null -)]
       _stdin, _stdout, std_err, wait_thr = Open3.popen3(*lkfs_command)
 
       if wait_thr.value.success?
         stats = JSON.parse(std_err.read.lines[-12, 12].join)
         @lkfs = stats['input_i'].to_f
+        @loudness_lra = stats['input_lra']
+        @loudness_threshold = stats['input_thresh']
+        @loudness_true_peak = stats['input_tp']
+        @target_offset = stats['target_offset']
+
+        # This attribute can be used as the input to 'loudness_normalization' when doing two-pass transcoding
+        @normalize_command = "loudnorm=I=-24:TP=-1.5:LRA=11:measured_I=#{@lkfs}"\
+          ":measured_LRA=#{@loudness_lra}:measured_TP=#{@loudness_true_peak}:measured_thresh"\
+          "=#{@loudness_threshold}:offset=#{@target_offset}:linear=true:print_format=summary"
       else
         raise "Could not retrieve lkfs"
       end
       std_err.flush
-    end
-
-    def set_mean_and_max_volume
-
     end
 
     def unsupported_streams(std_error)

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -155,7 +155,7 @@ module FFMPEG
 
       if wait_thr.value.success?
         stats = JSON.parse(std_err.read.lines[-12, 12].join)
-        @lkfs = stats['input_i'].to_f
+        @lkfs = stats['input_i']
         @loudness_lra = stats['input_lra']
         @loudness_threshold = stats['input_thresh']
         @loudness_true_peak = stats['input_tp']

--- a/spec/ffmpeg/encoding_options_spec.rb
+++ b/spec/ffmpeg/encoding_options_spec.rb
@@ -21,6 +21,13 @@ module FFMPEG
         expect(EncodingOptions.new(frame_rate: 29.9).to_a).to eq(%w(-r 29.9))
       end
 
+      it "should convert loudness normalization" do
+        command = "loudnorm=I=-24:TP=-1.5:"\
+            "LRA=11:measured_I=-62.95:measured_LRA=1.10:measured_TP=-37.62"\
+            ":measured_thresh=-72.95:offset=0.77:linear=true:print_format=summary"
+        expect(EncodingOptions.new(loudness_normalization: command).to_a).to include("-af", command)
+      end
+
       it "should convert the resolution" do
         expect(EncodingOptions.new(resolution: "640x480").to_a).to include("-s", "640x480")
       end

--- a/spec/ffmpeg/movie_spec.rb
+++ b/spec/ffmpeg/movie_spec.rb
@@ -392,6 +392,32 @@ module FFMPEG
           expect(movie.max_volume).to eq("-38.0 dB")
         end
 
+        it "should expose lkfs" do
+          expect(movie.lkfs).to eq("-62.95")
+        end
+
+        it "should expose loudness threshold" do
+          expect(movie.loudness_threshold).to eq("-72.95")
+        end
+
+        it "should expose loudness true peak" do
+          expect(movie.loudness_true_peak).to eq( "-37.62")
+        end
+
+        it "should expose loudness LRA" do
+          expect(movie.loudness_lra).to eq("1.10")
+        end
+
+        it "should expose loudness target offset" do
+          expect(movie.target_offset).to eq("0.77")
+        end
+
+        it "should calculate loudness 2-pass normalization command" do
+          expect(movie.normalize_command).to eq("loudnorm=I=-24:TP=-1.5:"\
+            "LRA=11:measured_I=-62.95:measured_LRA=1.10:measured_TP=-37.62"\
+            ":measured_thresh=-72.95:offset=0.77:linear=true:print_format=summary")
+        end
+
         it "should return nil rotation when no rotation exists" do
           expect(movie.rotation).to eq(nil)
         end


### PR DESCRIPTION
This pulls LKFS and related loudness data and sets them as attributes on the movie object. It also calculates the two-pass loudness normalization formula based on these inputs to normalize the movie to -24 LKFS. This can then be as the input to normalize_loudness during transcoding (see updated readme example).