### PR TITLE
Allow for custom HEAD request URLs

### DIFF
--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -13,11 +13,11 @@ module FFMPEG
 
     UNSUPPORTED_CODEC_PATTERN = /^Unsupported codec with id (\d+) for input stream (\d+)$/
 
-    def initialize(path)
+    def initialize(path, head_url: path)
       @path = path
 
       if remote?
-        @head = head
+        @head = head(head_url)
         unless @head.is_a?(Net::HTTPSuccess)
           raise Errno::ENOENT, "the URL '#{path}' does not exist or is not available (response code: #{@head.code})"
         end

--- a/spec/ffmpeg/movie_spec.rb
+++ b/spec/ffmpeg/movie_spec.rb
@@ -35,6 +35,15 @@ module FFMPEG
 
           let(:movie) { Movie.new("http://127.0.0.1:8000/awesome%20movie.mov") }
 
+          context "custom HEAD url" do
+            let(:head_url) { "http://google.com/does-not-exist.mov" }
+            let(:movie) { Movie.new("http://127.0.0.1:8000/awesome%20movie.mov", head_url: head_url) }
+
+            it "allows for a custome HEAD url location, like an S3 presigned url" do
+              expect { movie }.to raise_error(Errno::ENOENT)
+            end
+          end
+
           it "should be valid" do
             expect(movie).to be_valid
           end


### PR DESCRIPTION
When using an S3 presigned URL, you cannot obtain a URL for a private object that allows
for both a GET and a HEAD request on it.

Because of this, you need to:

```ruby
  head_url = object.presigned_url(:head)
  get_url = object.presigned_url(:get)
```

...independently of one another.

This means that you cannot get media information with this gem.

To _allow_ for this, I've added an option to pass in a custom head_url: argument to allow
for this separation.

In this manner, you can now do this:

```ruby
  movie = FFMPEG::Movie.new(object.presigned_url(:get), head_url: object.presigned_url(:head))
```

And obtain your information successfully.