### PR TITLE
Support when running with frozen string literals

### DIFF
--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -63,7 +63,7 @@ module FFMPEG
     # frame= 4855 fps= 46 q=31.0 size=   45306kB time=00:02:42.28 bitrate=2287.0kbits/
     def transcode_movie
       FFMPEG.logger.info("Running transcoding...\n#{command}\n")
-      @output = ""
+      @output = +""
 
       Open3.popen3(*command) do |_stdin, _stdout, stderr, wait_thr|
         begin


### PR DESCRIPTION
`RUBYOPT=--enable=frozen-string-literal bundle exec rspec`

Ruby is once again going in the direction of freezing strings by default. This is all that's needed here to make it compatible, at least according the the test suite and what I make use of from the gem myself.

I don't really expect this to be merged, the project looks pretty dead to me but maybe someone else will find this useful.